### PR TITLE
Add Coinbase agent vendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # AIArbitrage
+
+Simple cryptocurrency data ingestor demonstrating async Rust agents.
+
+## Available agents
+
+- `binance` – streams trade data for selected symbols via WebSocket.
+- `coinbase` – periodically polls spot prices for currency pairs using the REST API.
+

--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -1,0 +1,59 @@
+use crate::agent::Agent;
+
+pub struct CoinbaseAgent {
+    symbols: Vec<String>,
+    interval_secs: u64,
+}
+
+impl CoinbaseAgent {
+    pub fn new(symbols: Vec<String>) -> Self {
+        Self {
+            symbols,
+            interval_secs: 5,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Agent for CoinbaseAgent {
+    fn name(&self) -> &'static str {
+        "coinbase"
+    }
+
+    async fn run(
+        &mut self,
+        mut shutdown: tokio::sync::watch::Receiver<bool>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let client = reqwest::Client::new();
+        let mut interval =
+            tokio::time::interval(std::time::Duration::from_secs(self.interval_secs));
+        loop {
+            tokio::select! {
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() { break; }
+                }
+                _ = interval.tick() => {
+                    for sym in &self.symbols {
+                        let url = format!("https://api.coinbase.com/v2/prices/{sym}/spot");
+                        match client.get(&url).send().await {
+                            Ok(resp) => {
+                                match resp.json::<serde_json::Value>().await {
+                                    Ok(val) => {
+                                        let price = val.get("data")
+                                            .and_then(|d| d.get("amount"))
+                                            .and_then(|a| a.as_str())
+                                            .unwrap_or("?");
+                                        tracing::info!(%sym, %price, "coinbase spot");
+                                    }
+                                    Err(e) => tracing::error!(%sym, error=%e, "parse error"),
+                                }
+                            }
+                            Err(e) => tracing::error!(%sym, error=%e, "request error"),
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/crypto-ingestor/src/agents/mod.rs
+++ b/crypto-ingestor/src/agents/mod.rs
@@ -1,4 +1,5 @@
 pub mod binance;
+pub mod coinbase;
 
 use crate::agent::Agent;
 
@@ -31,10 +32,24 @@ pub async fn make_agent(spec: &str) -> Option<Box<dyn Agent>> {
                 }
             }
         }
+        "coinbase" => {
+            let symbols = if args.is_empty() {
+                vec!["BTC-USD".to_string()]
+            } else {
+                args.split(',')
+                    .map(|s| s.trim().to_uppercase())
+                    .filter(|s| !s.is_empty())
+                    .collect::<Vec<_>>()
+            };
+            Some(Box::new(coinbase::CoinbaseAgent::new(symbols)))
+        }
         _ => None,
     }
 }
 
 pub fn available_agents() -> &'static [&'static str] {
-    &["binance:<csv symbols|all>  (e.g. binance:btcusdt,ethusdt)"]
+    &[
+        "binance:<csv symbols|all>  (e.g. binance:btcusdt,ethusdt)",
+        "coinbase:<csv pairs>      (e.g. coinbase:BTC-USD,ETH-USD)",
+    ]
 }


### PR DESCRIPTION
## Summary
- Implement a Coinbase agent that polls spot prices via the Coinbase REST API
- Wire the new agent into the factory and document it alongside Binance

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68abd88ec1dc8323b51b30fa251dbfc2