### PR TITLE
Switch Coinbase agent to WebSocket streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # AIArbitrage
 
-Simple cryptocurrency data ingestor demonstrating async Rust agents.
+Simple cryptocurrency data ingestor demonstrating async Rust agents. Both
+Binance and Coinbase agents stream market data via WebSockets.
 
 ## Available agents
 
 - `binance` – streams trade data for selected symbols via WebSocket.
-- `coinbase` – periodically polls spot prices for currency pairs using the REST API.
+- `coinbase` – streams trade data for selected pairs via WebSocket.
 


### PR DESCRIPTION
## Summary
- replace Coinbase REST polling with WebSocket streaming client
- add reconnection and shutdown handling similar to BinanceAgent
- fetch Coinbase product IDs for USD pairs and update README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ac64a1d8088323adf03fb59c0a4fea