### PR TITLE
Introduce canonicalizer process for standardized trade symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,23 @@ Binance and Coinbase agents stream market data via WebSockets.
 - `binance` – streams trade data for selected symbols via WebSocket.
 - `coinbase` – streams trade data for selected pairs via WebSocket.
 
+## Canonicalizer
+
+The project includes a `canonicalizer` binary that normalizes symbols across
+exchanges. It reads trade messages as JSON lines on `STDIN`, converts the `s`
+field to the canonical `BASE-QUOTE` form using `canonical::CanonicalService`,
+and emits the modified JSON on `STDOUT`.
+
+The ingestor spawns this canonicalizer automatically so all output is already
+canonicalized:
+
+```bash
+cargo run --release -- binance:btcusdt coinbase:BTC-USD
+```
+
+Example pipeline sending canonicalized trades to another process:
+
+```bash
+cargo run --release -- binance:btcusdt coinbase:BTC-USD | jq '.'
+```
+

--- a/crypto-ingestor/Cargo.toml
+++ b/crypto-ingestor/Cargo.toml
@@ -2,9 +2,10 @@
 name = "ingestor"
 version = "0.1.1"
 edition = "2021"
+default-run = "ingestor"
 
 [dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "io-util", "process", "io-std"] }
 tokio-tungstenite = { version = "0.21", features = ["rustls-tls-webpki-roots"] }
 futures-util = "0.3"
 serde_json = "1"

--- a/crypto-ingestor/src/agent.rs
+++ b/crypto-ingestor/src/agent.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use tokio::sync::mpsc::Sender;
 
 #[async_trait]
 pub trait Agent: Send {
@@ -8,5 +9,6 @@ pub trait Agent: Send {
     async fn run(
         &mut self,
         shutdown: tokio::sync::watch::Receiver<bool>,
+        tx: Sender<String>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 }

--- a/crypto-ingestor/src/bin/canonicalizer.rs
+++ b/crypto-ingestor/src/bin/canonicalizer.rs
@@ -1,0 +1,40 @@
+use serde_json::Value;
+use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt};
+
+#[path = "../canonical.rs"]
+mod canonical;
+use canonical::CanonicalService;
+
+#[tokio::main]
+async fn main() -> io::Result<()> {
+    let stdin = io::BufReader::new(io::stdin());
+    let mut lines = stdin.lines();
+    let mut stdout = io::stdout();
+
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<Value>(&line) {
+            Ok(mut v) => {
+                if let (Some(exchange), Some(pair)) = (
+                    v.get("agent").and_then(|a| a.as_str()),
+                    v.get("s").and_then(|s| s.as_str()),
+                ) {
+                    if let Some(canon) = CanonicalService::canonical_pair(exchange, pair) {
+                        v["s"] = Value::String(canon);
+                    }
+                }
+                let out = serde_json::to_string(&v).unwrap_or(line);
+                stdout.write_all(out.as_bytes()).await?;
+                stdout.write_all(b"\n").await?;
+            }
+            Err(_) => {
+                stdout.write_all(line.as_bytes()).await?;
+                stdout.write_all(b"\n").await?;
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add standalone `canonicalizer` binary to normalize `s` symbols
- route agent output through the canonicalizer process via async pipes
- document canonicalized ingestion workflow in README

## Testing
- `cargo test`
- `echo '{"agent":"binance","type":"trade","s":"btcusdt"}' | cargo run --quiet --bin canonicalizer`


------
https://chatgpt.com/codex/tasks/task_e_68ac672cc24c83238a37829226b0cf72