### PR TITLE
Load Binance quotes dynamically

### DIFF
--- a/crypto-ingestor/src/bin/canonicalizer.rs
+++ b/crypto-ingestor/src/bin/canonicalizer.rs
@@ -7,6 +7,8 @@ use canonical::CanonicalService;
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
+    CanonicalService::init().await;
+
     let stdin = io::BufReader::new(io::stdin());
     let mut lines = stdin.lines();
     let mut stdout = io::stdout();


### PR DESCRIPTION
## Summary
- Fetch Binance quote assets at startup and cache them for canonicalization, with env-var override and graceful fallback on errors.
- Initialize quotes in the canonicalizer binary before processing pairs.
- Expand tests to cover dynamic quote lists, verifying canonicalization across multiple quotes.

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ac6bdf6cc483239bc9ca73b6461b81