### PR TITLE
Initialize canonical service before agent creation

### DIFF
--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -3,6 +3,7 @@ mod agents;
 mod canonical;
 
 use agents::{available_agents, make_agent};
+use canonical::CanonicalService;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use tokio::sync::mpsc;
@@ -76,6 +77,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             let _ = out.write_all(b"\n").await;
         }
     });
+
+    // Initialise the canonical service before any agents are created so that
+    // the required quote asset list is available for symbol comparisons.
+    CanonicalService::init().await;
 
     let mut handles = Vec::new();
     for spec in specs.drain(..) {


### PR DESCRIPTION
## Summary
- ensure CanonicalService is initialised in main before creating agents

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ac793fd94c832397862056f7f5178f