### PR TITLE
Standardize missing trade IDs across agents

### DIFF
--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -246,7 +246,10 @@ async fn connection_task(
 
                                         let raw = v.get("s").and_then(|s| s.as_str()).unwrap_or("?");
                                         let sym = CanonicalService::canonical_pair("binance", raw).unwrap_or_else(|| raw.to_string());
-                                        let trade_id = v.get("t").and_then(|t| t.as_i64()).unwrap_or_default();
+                                        let trade_id = v
+                                            .get("t")
+                                            .and_then(|t| t.as_i64())
+                                            .filter(|id| *id > 0);
                                         let px = v.get("p").and_then(|p| p.as_str()).unwrap_or("?");
                                         let qty = v.get("q").and_then(|q| q.as_str()).unwrap_or("?");
                                         let ts = v.get("T").and_then(|x| x.as_i64()).unwrap_or_default();

--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -104,7 +104,10 @@ async fn connection_task(
                                         if typ == "match" {
                                             let raw = v.get("product_id").and_then(|s| s.as_str()).unwrap_or("?");
                                             let sym = CanonicalService::canonical_pair("coinbase", raw).unwrap_or_else(|| raw.to_string());
-                                            let trade_id = v.get("trade_id").and_then(|id| id.as_i64());
+                                            let trade_id = v
+                                                .get("trade_id")
+                                                .and_then(|id| id.as_i64())
+                                                .filter(|id| *id > 0);
                                             let price = v.get("price").and_then(|p| p.as_str()).unwrap_or("?");
                                             let size = v.get("size").and_then(|q| q.as_str()).unwrap_or("?");
                                             let ts = v


### PR DESCRIPTION
## Summary
- treat absent trade IDs as `null`
- ensure Binance agent doesn't substitute missing IDs with `0`
- document unified handling in Coinbase trade stream

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ac794177c883238f026e5f8d80219a