### PR TITLE
feat: split canonicalizer into dedicated crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "canonicalizer"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +574,7 @@ name = "ingestor"
 version = "0.1.1"
 dependencies = [
  "async-trait",
+ "canonicalizer",
  "chrono",
  "futures-util",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = [
+    "crypto-ingestor",
+    "canonicalizer",
+]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 Simple cryptocurrency data ingestor demonstrating async Rust agents. Both
 Binance and Coinbase agents stream market data via WebSockets.
 
+This repository is organised as a Cargo workspace containing two crates:
+
+- `crypto-ingestor` – the main executable that spawns exchange agents.
+- `canonicalizer` – a standalone service crate providing a library and binary
+  for converting exchange-specific symbols into a canonical `BASE-QUOTE` form.
+
 ## Available agents
 
 - `binance` – streams trade data for selected symbols via WebSocket.
@@ -10,10 +16,11 @@ Binance and Coinbase agents stream market data via WebSockets.
 
 ## Canonicalizer
 
-The project includes a `canonicalizer` binary that normalizes symbols across
-exchanges. It reads trade messages as JSON lines on `STDIN`, converts the `s`
-field to the canonical `BASE-QUOTE` form using `canonical::CanonicalService`,
-and emits the modified JSON on `STDOUT`.
+The `canonicalizer` crate provides both the `CanonicalService` library and a
+`canonicalizer` binary that normalizes symbols across exchanges. The binary
+reads trade messages as JSON lines on `STDIN`, converts the `s` field to the
+canonical `BASE-QUOTE` form using `canonicalizer::CanonicalService`, and emits
+the modified JSON on `STDOUT`.
 
 The ingestor spawns this canonicalizer automatically so all output is already
 canonicalized:
@@ -26,6 +33,12 @@ Example pipeline sending canonicalized trades to another process:
 
 ```bash
 cargo run --release -- binance:btcusdt coinbase:BTC-USD | jq '.'
+```
+
+To run the canonicalizer service on its own:
+
+```bash
+cargo run -p canonicalizer
 ```
 
 ## Trade format

--- a/canonicalizer/Cargo.toml
+++ b/canonicalizer/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "canonicalizer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "io-util"] }
+reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false }
+serde_json = "1"
+tracing = "0.1"
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "canonicalizer"
+path = "src/main.rs"

--- a/canonicalizer/src/lib.rs
+++ b/canonicalizer/src/lib.rs
@@ -6,7 +6,6 @@
 /// `BASE-QUOTE` form are normalized to uppercase.
 ///
 /// Additional exchanges can be supported by extending `canonical_pair`.
-
 use std::collections::HashSet;
 use std::sync::OnceLock;
 

--- a/canonicalizer/src/main.rs
+++ b/canonicalizer/src/main.rs
@@ -1,9 +1,7 @@
 use serde_json::Value;
 use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt};
 
-#[path = "../canonical.rs"]
-mod canonical;
-use canonical::CanonicalService;
+use canonicalizer::CanonicalService;
 
 #[tokio::main]
 async fn main() -> io::Result<()> {

--- a/crypto-ingestor/Cargo.toml
+++ b/crypto-ingestor/Cargo.toml
@@ -14,6 +14,7 @@ reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-feature
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 chrono = "0.4"
+canonicalizer = { path = "../canonicalizer" }
 
 [profile.release]
 opt-level = 3

--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -3,7 +3,8 @@ use std::collections::HashSet;
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
 
-use crate::{agent::Agent, canonical::CanonicalService};
+use crate::agent::Agent;
+use canonicalizer::CanonicalService;
 
 const MAX_STREAMS_PER_CONN: usize = 1024; // per Binance docs
 const WS_URL: &str = "wss://stream.binance.us:9443/ws";

--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -2,7 +2,8 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
 
-use crate::{agent::Agent, canonical::CanonicalService};
+use crate::agent::Agent;
+use canonicalizer::CanonicalService;
 
 const WS_URL: &str = "wss://ws-feed.exchange.coinbase.com";
 

--- a/crypto-ingestor/src/agents/mod.rs
+++ b/crypto-ingestor/src/agents/mod.rs
@@ -1,7 +1,8 @@
 pub mod binance;
 pub mod coinbase;
 
-use crate::{agent::Agent, canonical::CanonicalService};
+use crate::agent::Agent;
+use canonicalizer::CanonicalService;
 use std::collections::HashMap;
 
 async fn shared_symbols(

--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -1,6 +1,5 @@
 mod agent;
 mod agents;
-mod canonical;
 
 use agents::{available_agents, make_agent};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};


### PR DESCRIPTION
## Summary
- move canonicalization logic into new `canonicalizer` crate with library and binary
- configure Cargo workspace for `crypto-ingestor` and `canonicalizer`
- update agents and ingestor to depend on external canonicalizer service
- document standalone canonicalizer usage

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ac81e9066483238501a6ded54d20ae