### PR TITLE
Use canonicalizer crate in ingestor

### DIFF
--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -2,7 +2,7 @@ mod agent;
 mod agents;
 
 use agents::{available_agents, make_agent};
-use canonical::CanonicalService;
+use canonicalizer::CanonicalService;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use tokio::sync::mpsc;


### PR DESCRIPTION
## Summary
- fix import to use `canonicalizer::CanonicalService`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ac94f14a0c832399b589c125e4892f