### PR TITLE
Normalize missing trade IDs as JSON null

### DIFF
--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -5,6 +5,7 @@ use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, Web
 
 use crate::agent::Agent;
 use canonicalizer::CanonicalService;
+use serde_json::Value;
 
 const MAX_STREAMS_PER_CONN: usize = 1024; // per Binance docs
 const WS_URL: &str = "wss://stream.binance.us:9443/ws";
@@ -247,10 +248,13 @@ async fn connection_task(
 
                                         let raw = v.get("s").and_then(|s| s.as_str()).unwrap_or("?");
                                         let sym = CanonicalService::canonical_pair("binance", raw).unwrap_or_else(|| raw.to_string());
+                                        // Missing or non-positive trade IDs are represented as JSON null.
                                         let trade_id = v
                                             .get("t")
                                             .and_then(|t| t.as_i64())
-                                            .filter(|id| *id > 0);
+                                            .filter(|id| *id > 0)
+                                            .map(Value::from)
+                                            .unwrap_or(Value::Null);
                                         let px = v.get("p").and_then(|p| p.as_str()).unwrap_or("?");
                                         let qty = v.get("q").and_then(|q| q.as_str()).unwrap_or("?");
                                         let ts = v.get("T").and_then(|x| x.as_i64()).unwrap_or_default();


### PR DESCRIPTION
## Summary
- Normalize missing trade IDs to JSON `null` for Binance and Coinbase agents
- Clarify handling of absent trade IDs before JSON serialization

## Testing
- `cargo test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac96f962c08323b9a020a9d3133332