### PR TITLE
refactor: consolidate websocket no-op handling

### DIFF
--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -270,11 +270,9 @@ async fn connection_task(
                                         tracing::warn!("non-json text msg");
                                     }
                                 }
-                                Some(Ok(Message::Binary(_))) => { }
-                                Some(Ok(Message::Frame(_))) => { }
                                 Some(Ok(Message::Ping(p))) => { let _ = ws.send(Message::Pong(p)).await; }
-                                Some(Ok(Message::Pong(_))) => { }
                                 Some(Ok(Message::Close(frame))) => { tracing::warn!(?frame, "server closed connection"); break; }
+                                Some(Ok(_)) => { }
                                 Some(Err(e)) => { tracing::error!(error=%e, "ws error"); break; }
                                 None => { tracing::warn!("stream ended"); break; }
                             }

--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -134,11 +134,9 @@ async fn connection_task(
                                         tracing::warn!("non-json text msg");
                                     }
                                 }
-                                Some(Ok(Message::Binary(_))) => { }
-                                Some(Ok(Message::Frame(_))) => { }
                                 Some(Ok(Message::Ping(p))) => { let _ = ws.send(Message::Pong(p)).await; }
-                                Some(Ok(Message::Pong(_))) => { }
                                 Some(Ok(Message::Close(frame))) => { tracing::warn!(?frame, "server closed connection"); break; }
+                                Some(Ok(_)) => { }
                                 Some(Err(e)) => { tracing::error!(error=%e, "ws error"); break; }
                                 None => { tracing::warn!("stream ended"); break; }
                             }


### PR DESCRIPTION
## Summary
- simplify WebSocket message match arms in Binance and Coinbase agents by using a catch-all for unhandled variants
- keep explicit handling for ping/pong, close, and error cases

## Testing
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68ac9703e7ac83238ad91191fd31b434