### PR TITLE
Initialize canonicalizer before comparing symbols

### DIFF
--- a/crypto-ingestor/src/agents/mod.rs
+++ b/crypto-ingestor/src/agents/mod.rs
@@ -7,6 +7,10 @@ use std::collections::HashMap;
 
 async fn shared_symbols(
 ) -> Result<(Vec<String>, Vec<String>), Box<dyn std::error::Error + Send + Sync>> {
+    // Ensure that the canonicalizer has loaded the quote asset list before we
+    // attempt any symbol comparisons.
+    CanonicalService::init().await;
+
     let (binance_all, coinbase_all) =
         tokio::try_join!(binance::fetch_all_symbols(), coinbase::fetch_all_symbols())?;
 


### PR DESCRIPTION
## Summary
- Ensure `shared_symbols` initializes `CanonicalService` so quote assets are loaded before symbol comparisons.

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ac96f86a208323bb57f42900f35746