### PR TITLE
Fix canonicalizer build and ignore invalid TLS certs for exchange info

### DIFF
--- a/canonicalizer/src/lib.rs
+++ b/canonicalizer/src/lib.rs
@@ -63,7 +63,10 @@ impl CanonicalService {
     }
 
     async fn fetch_binance_quotes() -> Result<Vec<String>, reqwest::Error> {
-        let v: serde_json::Value = reqwest::Client::new()
+        let client = reqwest::Client::builder()
+            .danger_accept_invalid_certs(true)
+            .build()?;
+        let v: serde_json::Value = client
             .get("https://api.binance.us/api/v3/exchangeInfo")
             .send()
             .await?

--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -11,7 +11,10 @@ const WS_URL: &str = "wss://stream.binance.us:9443/ws";
 
 /// Fetch all tradable symbols from Binance US REST API.
 pub async fn fetch_all_symbols() -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
-    let resp: serde_json::Value = reqwest::Client::new()
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()?;
+    let resp: serde_json::Value = client
         .get("https://api.binance.us/api/v3/exchangeInfo")
         .send()
         .await?

--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -9,7 +9,10 @@ const WS_URL: &str = "wss://ws-feed.exchange.coinbase.com";
 
 /// Fetch all tradable USD product IDs from Coinbase.
 pub async fn fetch_all_symbols() -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
-    let products: serde_json::Value = reqwest::Client::new()
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()?;
+    let products: serde_json::Value = client
         .get("https://api.exchange.coinbase.com/products")
         .send()
         .await?

--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -35,7 +35,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let canon_path = exe.with_file_name("canonicalizer");
     if !canon_path.exists() {
         let mut build = Command::new("cargo");
-        build.arg("build").arg("--bin").arg("canonicalizer");
+        build
+            .arg("build")
+            .arg("-p")
+            .arg("canonicalizer")
+            .arg("--bin")
+            .arg("canonicalizer");
         if !cfg!(debug_assertions) {
             build.arg("--release");
         }


### PR DESCRIPTION
## Summary
- Build canonicalizer automatically when missing
- Allow canonicalizer to fetch Binance quotes despite invalid TLS certs
- Tolerate invalid TLS certs when Binance and Coinbase agents fetch symbols

## Testing
- `cargo run --release 'binance:all' 'coinbase:all'` *(fails: IO error Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9d47a67083239918c67a3580245c