### PR TITLE
Configure workspace resolver and release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,7 @@ members = [
     "crypto-ingestor",
     "canonicalizer",
 ]
+resolver = "2"
+
+[profile.release]
+opt-level = 3

--- a/crypto-ingestor/Cargo.toml
+++ b/crypto-ingestor/Cargo.toml
@@ -15,6 +15,3 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 chrono = "0.4"
 canonicalizer = { path = "../canonicalizer" }
-
-[profile.release]
-opt-level = 3


### PR DESCRIPTION
## Summary
- set workspace resolver to "2"
- define release profile with `opt-level = 3` in the root manifest
- remove crate-specific release profile from `crypto-ingestor`

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68acb76b2d5c83239d3a0cf98cd1cfcc