### PR TITLE
Harden HTTP clients with optional TLS override

### DIFF
--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
 
-use crate::agent::Agent;
+use crate::{agent::Agent, http_client};
 use canonicalizer::CanonicalService;
 
 const MAX_STREAMS_PER_CONN: usize = 1024; // per Binance docs
@@ -11,9 +11,7 @@ const WS_URL: &str = "wss://stream.binance.us:9443/ws";
 
 /// Fetch all tradable symbols from Binance US REST API.
 pub async fn fetch_all_symbols() -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
-    let client = reqwest::Client::builder()
-        .danger_accept_invalid_certs(true)
-        .build()?;
+    let client = http_client::builder().build()?;
     let resp: serde_json::Value = client
         .get("https://api.binance.us/api/v3/exchangeInfo")
         .send()

--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -2,16 +2,14 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
 
-use crate::agent::Agent;
+use crate::{agent::Agent, http_client};
 use canonicalizer::CanonicalService;
 
 const WS_URL: &str = "wss://ws-feed.exchange.coinbase.com";
 
 /// Fetch all tradable USD product IDs from Coinbase.
 pub async fn fetch_all_symbols() -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
-    let client = reqwest::Client::builder()
-        .danger_accept_invalid_certs(true)
-        .build()?;
+    let client = http_client::builder().build()?;
     let products: serde_json::Value = client
         .get("https://api.exchange.coinbase.com/products")
         .send()

--- a/crypto-ingestor/src/http_client.rs
+++ b/crypto-ingestor/src/http_client.rs
@@ -1,0 +1,19 @@
+use reqwest::ClientBuilder;
+
+/// Build a `reqwest::ClientBuilder` configured for the current runtime.
+///
+/// Certificate verification is enabled by default.  To opt out (for example,
+/// when working with self-signed certificates in development), set the
+/// environment variable `INGESTOR_ACCEPT_INVALID_CERTS` to a truthy value
+/// (`1`, `true`, `yes`).  Disabling certificate verification is strongly
+/// discouraged for production use.
+pub fn builder() -> ClientBuilder {
+    let mut builder = reqwest::Client::builder();
+    let allow_invalid = std::env::var("INGESTOR_ACCEPT_INVALID_CERTS")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false);
+    if allow_invalid {
+        builder = builder.danger_accept_invalid_certs(true);
+    }
+    builder
+}

--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -1,5 +1,6 @@
 mod agent;
 mod agents;
+mod http_client;
 
 use agents::{available_agents, make_agent};
 use canonicalizer::CanonicalService;


### PR DESCRIPTION
## Summary
- prevent Binance and Coinbase agents from blindly accepting invalid TLS certs
- add shared HTTP client builder that verifies certificates by default
- allow opt-in disabling of TLS checks via `INGESTOR_ACCEPT_INVALID_CERTS`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68acb6f43e0c832398f208c8bc28ff5a