### PR TITLE
Add Prometheus metrics and HTTP endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,9 @@ dependencies = [
  "clap",
  "config",
  "futures-util",
+ "hyper",
+ "once_cell",
+ "prometheus",
  "reqwest",
  "rust_decimal",
  "serde",
@@ -890,6 +893,16 @@ name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1002,6 +1015,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,6 +1142,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,6 +1225,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -1382,6 +1448,12 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"

--- a/crypto-ingestor/Cargo.toml
+++ b/crypto-ingestor/Cargo.toml
@@ -17,6 +17,10 @@ tracing-subscriber = { version = "0.3", features = ["fmt"] }
 chrono = "0.4"
 canonicalizer = { path = "../canonicalizer" }
 
+prometheus = "0.13"
+hyper = { version = "0.14", features = ["full"] }
+once_cell = "1"
+
 clap = { version = "4", features = ["derive"] }
 config = "0.13"
 

--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -4,7 +4,12 @@ use std::collections::HashSet;
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
 
-use crate::{agent::Agent, config::Settings, http_client};
+use crate::{
+    agent::Agent,
+    config::Settings,
+    http_client,
+    metrics::{ERRORS, RECONNECTS, TRADES_RECEIVED},
+};
 use canonicalizer::CanonicalService;
 
 const MAX_STREAMS_PER_CONN: usize = 1024; // per Binance docs
@@ -208,6 +213,7 @@ async fn connection_task(
 
                 if let Err(e) = send_subscribe(&mut ws, &current_symbols).await {
                     tracing::error!(error=%e, "failed to send subscription");
+                    ERRORS.with_label_values(&["binance"]).inc();
                     continue;
                 }
 
@@ -235,6 +241,7 @@ async fn connection_task(
                                     if !to_sub.is_empty() {
                                         if let Err(e) = send_subscribe(&mut ws, &to_sub).await {
                                             tracing::error!(error=%e, "failed to update subscription");
+                                            ERRORS.with_label_values(&["binance"]).inc();
                                             break;
                                         }
                                     }
@@ -285,7 +292,9 @@ async fn connection_task(
                                             "q": qty,
                                             "ts": ts
                                         }).to_string();
-                                        if tx.send(line).await.is_err() {
+                                        if tx.send(line).await.is_ok() {
+                                            TRADES_RECEIVED.with_label_values(&["binance"]).inc();
+                                        } else {
                                             break;
                                         }
                                     } else {
@@ -295,7 +304,7 @@ async fn connection_task(
                                 Some(Ok(Message::Ping(p))) => { let _ = ws.send(Message::Pong(p)).await; }
                                 Some(Ok(Message::Close(frame))) => { tracing::warn!(?frame, "server closed connection"); break; }
                                 Some(Ok(_)) => { }
-                                Some(Err(e)) => { tracing::error!(error=%e, "ws error"); break; }
+                                Some(Err(e)) => { tracing::error!(error=%e, "ws error"); ERRORS.with_label_values(&["binance"]).inc(); break; }
                                 None => { tracing::warn!("stream ended"); break; }
                             }
                         }
@@ -304,6 +313,7 @@ async fn connection_task(
             }
             Err(e) => {
                 tracing::error!(error=%e, "connect failed");
+                ERRORS.with_label_values(&["binance"]).inc();
             }
         }
 
@@ -312,6 +322,7 @@ async fn connection_task(
         let delay = (1u64 << exp).min(max_reconnect_delay_secs);
         let sleep = std::time::Duration::from_secs(delay);
 
+        RECONNECTS.with_label_values(&["binance"]).inc();
         tracing::info!(?sleep, "reconnecting");
         tokio::select! {
             _ = tokio::time::sleep(sleep) => {},

--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -3,9 +3,13 @@ use rust_decimal::Decimal;
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
 
-use crate::{agent::Agent, config::Settings, http_client};
+use crate::{
+    agent::Agent,
+    config::Settings,
+    http_client,
+    metrics::{ERRORS, RECONNECTS, TRADES_RECEIVED},
+};
 use canonicalizer::CanonicalService;
-
 
 /// Fetch all tradable USD product IDs from Coinbase.
 pub async fn fetch_all_symbols() -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
@@ -96,6 +100,7 @@ async fn connection_task(
 
                 if let Err(e) = send_subscribe(&mut ws, &symbols).await {
                     tracing::error!(error=%e, "failed to send subscription");
+                    ERRORS.with_label_values(&["coinbase"]).inc();
                     continue;
                 }
 
@@ -146,7 +151,9 @@ async fn connection_task(
                                                 "q": size,
                                                 "ts": ts
                                             }).to_string();
-                                            if tx.send(line).await.is_err() {
+                                            if tx.send(line).await.is_ok() {
+                                                TRADES_RECEIVED.with_label_values(&["coinbase"]).inc();
+                                            } else {
                                                 break;
                                             }
                                         }
@@ -157,7 +164,7 @@ async fn connection_task(
                                 Some(Ok(Message::Ping(p))) => { let _ = ws.send(Message::Pong(p)).await; }
                                 Some(Ok(Message::Close(frame))) => { tracing::warn!(?frame, "server closed connection"); break; }
                                 Some(Ok(_)) => { }
-                                Some(Err(e)) => { tracing::error!(error=%e, "ws error"); break; }
+                                Some(Err(e)) => { tracing::error!(error=%e, "ws error"); ERRORS.with_label_values(&["coinbase"]).inc(); break; }
                                 None => { tracing::warn!("stream ended"); break; }
                             }
                         }
@@ -166,6 +173,7 @@ async fn connection_task(
             }
             Err(e) => {
                 tracing::error!(error=%e, "connect failed");
+                ERRORS.with_label_values(&["coinbase"]).inc();
             }
         }
 
@@ -174,6 +182,7 @@ async fn connection_task(
         let delay = (1u64 << exp).min(max_reconnect_delay_secs);
         let sleep = std::time::Duration::from_secs(delay);
 
+        RECONNECTS.with_label_values(&["coinbase"]).inc();
         tracing::info!(?sleep, "reconnecting");
         tokio::select! {
             _ = tokio::time::sleep(sleep) => {},

--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -2,6 +2,7 @@ mod agent;
 mod agents;
 mod config;
 mod http_client;
+mod metrics;
 
 use agents::{available_agents, make_agent};
 use canonicalizer::CanonicalService;
@@ -33,6 +34,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         std::process::exit(2);
     }
     let settings = Settings::load(&cli)?;
+
+    // metrics server
+    tokio::spawn(metrics::serve(([0, 0, 0, 0], 9898).into()));
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 

--- a/crypto-ingestor/src/metrics.rs
+++ b/crypto-ingestor/src/metrics.rs
@@ -1,0 +1,50 @@
+use once_cell::sync::Lazy;
+use prometheus::{gather, register_int_counter_vec, Encoder, IntCounterVec, TextEncoder};
+use std::net::SocketAddr;
+
+pub static TRADES_RECEIVED: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "trades_received_total",
+        "Total number of trades received",
+        &["agent"]
+    )
+    .unwrap()
+});
+
+pub static RECONNECTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "reconnections_total",
+        "Total number of reconnection attempts",
+        &["agent"]
+    )
+    .unwrap()
+});
+
+pub static ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!("errors_total", "Total number of errors", &["agent"]).unwrap()
+});
+
+async fn metrics_handler(
+    _req: hyper::Request<hyper::Body>,
+) -> Result<hyper::Response<hyper::Body>, hyper::Error> {
+    let mut buffer = Vec::new();
+    let encoder = TextEncoder::new();
+    let metric_families = gather();
+    encoder.encode(&metric_families, &mut buffer).unwrap();
+
+    Ok(hyper::Response::builder()
+        .status(200)
+        .header(hyper::header::CONTENT_TYPE, encoder.format_type())
+        .body(hyper::Body::from(buffer))
+        .unwrap())
+}
+
+pub async fn serve(addr: SocketAddr) {
+    use hyper::service::{make_service_fn, service_fn};
+
+    let make_svc =
+        make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(metrics_handler)) });
+    if let Err(e) = hyper::Server::bind(&addr).serve(make_svc).await {
+        eprintln!("metrics server error: {e}");
+    }
+}


### PR DESCRIPTION
## Summary
- Add Prometheus-based metrics module with counters for trades, reconnections and errors
- Instrument Binance and Coinbase agents to record trade counts, reconnection attempts and error occurrences
- Expose collected metrics on port 9898 via a lightweight Hyper HTTP server

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68acbd2a0b248323bade0e13f2be0ca2