### PR TITLE
Add WebSocket tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+          override: true
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features
+      - name: Test
+        run: cargo test

--- a/crypto-ingestor/src/lib.rs
+++ b/crypto-ingestor/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod agent;
+pub mod agents;
+pub mod config;
+pub mod http_client;

--- a/crypto-ingestor/tests/ws.rs
+++ b/crypto-ingestor/tests/ws.rs
@@ -1,0 +1,116 @@
+use futures_util::{SinkExt, StreamExt};
+use serde_json::json;
+use tokio::net::TcpListener;
+use tokio::sync::{mpsc, watch};
+use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+use ingestor::agent::Agent;
+use ingestor::agents::{binance::BinanceAgent, coinbase::CoinbaseAgent};
+use ingestor::config::Settings;
+
+#[tokio::test]
+async fn coinbase_trade_messages_are_canonicalized_with_id() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = accept_async(stream).await.unwrap();
+        // read subscription
+        let _ = ws.next().await;
+        let msg = json!({
+            "type": "match",
+            "product_id": "eth-usd",
+            "trade_id": 42,
+            "price": "100.00",
+            "size": "0.5",
+            "time": "2024-01-01T00:00:00Z"
+        })
+        .to_string();
+        ws.send(Message::Text(msg)).await.unwrap();
+        // wait for client close
+        let _ = ws.next().await;
+    });
+
+    let cfg = Settings {
+        binance_ws_url: "ws://localhost".into(),
+        binance_refresh_interval_mins: 60,
+        binance_max_reconnect_delay_secs: 1,
+        coinbase_ws_url: format!("ws://{}", addr),
+        coinbase_max_reconnect_delay_secs: 1,
+    };
+
+    let mut agent = CoinbaseAgent::new(vec!["ETH-USD".into()], &cfg);
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (tx, mut rx) = mpsc::channel::<String>(1);
+
+    let handle = tokio::spawn(async move {
+        agent.run(shutdown_rx, tx).await.unwrap();
+    });
+
+    let line = rx.recv().await.expect("no message");
+    let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+    assert_eq!(v["s"], "ETH-USD");
+    assert_eq!(v["t"], 42);
+    assert_eq!(v["p"], "100");
+    assert_eq!(v["q"], "0.5");
+
+    shutdown_tx.send(true).unwrap();
+    handle.await.unwrap();
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn binance_trade_messages_are_canonicalized_with_id() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = accept_async(stream).await.unwrap();
+        // read subscription
+        let _ = ws.next().await;
+        // send ack
+        let ack = json!({"id":1}).to_string();
+        ws.send(Message::Text(ack)).await.unwrap();
+        let msg = json!({
+            "s": "btcusdt",
+            "t": 7,
+            "p": "50.00",
+            "q": "0.1",
+            "T": 1
+        })
+        .to_string();
+        ws.send(Message::Text(msg)).await.unwrap();
+        let _ = ws.next().await;
+    });
+
+    let cfg = Settings {
+        binance_ws_url: format!("ws://{}", addr),
+        binance_refresh_interval_mins: 60,
+        binance_max_reconnect_delay_secs: 1,
+        coinbase_ws_url: "ws://localhost".into(),
+        coinbase_max_reconnect_delay_secs: 1,
+    };
+
+    let mut agent = BinanceAgent::new(Some(vec!["btcusdt".into()]), &cfg)
+        .await
+        .unwrap();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (tx, mut rx) = mpsc::channel::<String>(1);
+
+    let handle = tokio::spawn(async move {
+        agent.run(shutdown_rx, tx).await.unwrap();
+    });
+
+    let line = rx.recv().await.expect("no message");
+    let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+    assert_eq!(v["s"], "BTC-USDT");
+    assert_eq!(v["t"], 7);
+    assert_eq!(v["p"], "50");
+    assert_eq!(v["q"], "0.1");
+
+    shutdown_tx.send(true).unwrap();
+    handle.await.unwrap();
+    server.await.unwrap();
+}


### PR DESCRIPTION
## Summary
- add integration tests for coinbase and binance agents verifying trade canonicalization and trade IDs
- expose ingestor modules via library crate
- add CI workflow to run formatting, clippy, and tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68acbd2eb6548323bc36a6a0933b34dc