### PR TITLE
Restart canonicalizer with watchdog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,7 +570,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -807,6 +819,7 @@ dependencies = [
  "clap",
  "config",
  "futures-util",
+ "metrics",
  "reqwest",
  "rust_decimal",
  "serde",
@@ -902,6 +915,28 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "metrics"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+dependencies = [
+ "ahash 0.8.12",
+ "metrics-macros",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "mime"
@@ -1068,6 +1103,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"

--- a/crypto-ingestor/Cargo.toml
+++ b/crypto-ingestor/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4", features = ["derive"] }
 config = "0.13"
 
 rust_decimal = "1"
+metrics = "0.21"
 
 [profile.release]
 opt-level = 3

--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -55,36 +55,66 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             return Err("failed to build canonicalizer".into());
         }
     }
-    let mut canon_child = Command::new(&canon_path)
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .spawn()?;
+    let (tx, rx) = mpsc::channel::<String>(100);
 
-    let canon_stdin = canon_child.stdin.take().expect("canonicalizer stdin");
-    let canon_stdout = canon_child.stdout.take().expect("canonicalizer stdout");
+    // spawn watchdog for canonicalizer process
+    let canon_path_clone = canon_path.clone();
+    let canon_watchdog = tokio::spawn(async move {
+        let mut rx = rx;
+        loop {
+            let mut canon_child = match Command::new(&canon_path_clone)
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::piped())
+                .spawn()
+            {
+                Ok(child) => child,
+                Err(e) => {
+                    tracing::error!(error=%e, "failed to spawn canonicalizer");
+                    return;
+                }
+            };
 
-    let (tx, mut rx) = mpsc::channel::<String>(100);
+            let mut canon_stdin = canon_child.stdin.take().expect("canonicalizer stdin");
+            let canon_stdout = canon_child.stdout.take().expect("canonicalizer stdout");
+            let mut reader = tokio::io::BufReader::new(canon_stdout).lines();
+            let mut out = tokio::io::stdout();
 
-    // writer task
-    tokio::spawn(async move {
-        let mut stdin = canon_stdin;
-        while let Some(line) = rx.recv().await {
-            if stdin.write_all(line.as_bytes()).await.is_err() {
-                break;
+            loop {
+                tokio::select! {
+                    line = rx.recv() => {
+                        match line {
+                            Some(line) => {
+                                if canon_stdin.write_all(line.as_bytes()).await.is_err() {
+                                    break;
+                                }
+                                if canon_stdin.write_all(b"\n").await.is_err() {
+                                    break;
+                                }
+                            }
+                            None => {
+                                let _ = canon_child.kill().await;
+                                return;
+                            }
+                        }
+                    }
+                    res = reader.next_line() => {
+                        match res {
+                            Ok(Some(line)) => {
+                                let _ = out.write_all(line.as_bytes()).await;
+                                let _ = out.write_all(b"\n").await;
+                            }
+                            _ => break,
+                        }
+                    }
+                    status = canon_child.wait() => {
+                        tracing::warn!(?status, "canonicalizer exited; restarting");
+                        metrics::counter!("canonicalizer_restarts", 1);
+                        break;
+                    }
+                }
             }
-            if stdin.write_all(b"\n").await.is_err() {
-                break;
-            }
-        }
-    });
 
-    // reader task
-    tokio::spawn(async move {
-        let mut reader = tokio::io::BufReader::new(canon_stdout).lines();
-        let mut out = tokio::io::stdout();
-        while let Ok(Some(line)) = reader.next_line().await {
-            let _ = out.write_all(line.as_bytes()).await;
-            let _ = out.write_all(b"\n").await;
+            let _ = canon_child.kill().await;
         }
     });
 
@@ -131,7 +161,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     }
 
     drop(tx);
-    let _ = canon_child.wait().await;
+    let _ = canon_watchdog.await;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- restart canonicalizer automatically when it exits and log/metric restart events
- add metrics crate for restart counter

## Testing
- `cargo test -p ingestor`


------
https://chatgpt.com/codex/tasks/task_e_68acbd2cc4748323acea6ad35cba122b