### PR TITLE
Introduce shared error type for agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite",
  "tracing",

--- a/crypto-ingestor/Cargo.toml
+++ b/crypto-ingestor/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4", features = ["derive"] }
 config = "0.13"
 
 rust_decimal = "1"
+thiserror = "1"
 
 [profile.release]
 opt-level = 3

--- a/crypto-ingestor/src/agent.rs
+++ b/crypto-ingestor/src/agent.rs
@@ -1,6 +1,8 @@
 use async_trait::async_trait;
 use tokio::sync::mpsc::Sender;
 
+use crate::error::IngestorError;
+
 #[async_trait]
 pub trait Agent: Send {
     fn name(&self) -> &'static str;
@@ -10,5 +12,5 @@ pub trait Agent: Send {
         &mut self,
         shutdown: tokio::sync::watch::Receiver<bool>,
         tx: Sender<String>,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
+    ) -> Result<(), IngestorError>;
 }

--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -4,20 +4,34 @@ use std::collections::HashSet;
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
 
-use crate::{agent::Agent, config::Settings, http_client};
+use crate::{agent::Agent, config::Settings, error::IngestorError, http_client};
 use canonicalizer::CanonicalService;
 
 const MAX_STREAMS_PER_CONN: usize = 1024; // per Binance docs
 
 /// Fetch all tradable symbols from Binance US REST API.
-pub async fn fetch_all_symbols() -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
-    let client = http_client::builder().build()?;
+pub async fn fetch_all_symbols() -> Result<Vec<String>, IngestorError> {
+    let client = http_client::builder().build().map_err(|e| IngestorError::Http {
+        source: e,
+        exchange: "binance",
+        symbol: None,
+    })?;
     let resp: serde_json::Value = client
         .get("https://api.binance.us/api/v3/exchangeInfo")
         .send()
-        .await?
+        .await
+        .map_err(|e| IngestorError::Http {
+            source: e,
+            exchange: "binance",
+            symbol: None,
+        })?
         .json()
-        .await?;
+        .await
+        .map_err(|e| IngestorError::Http {
+            source: e,
+            exchange: "binance",
+            symbol: None,
+        })?;
 
     let symbols = resp
         .get("symbols")
@@ -59,7 +73,7 @@ impl BinanceAgent {
     pub async fn new(
         symbols: Option<Vec<String>>,
         cfg: &Settings,
-    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Self, IngestorError> {
         let symbols = match symbols {
             Some(v) => v,
             None => fetch_all_symbols().await?,
@@ -84,7 +98,7 @@ impl Agent for BinanceAgent {
         &mut self,
         mut shutdown: tokio::sync::watch::Receiver<bool>,
         out_tx: mpsc::Sender<String>,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<(), IngestorError> {
         let mut handles = Vec::new();
         let mut symbol_txs = Vec::new();
 

--- a/crypto-ingestor/src/agents/mod.rs
+++ b/crypto-ingestor/src/agents/mod.rs
@@ -1,12 +1,11 @@
 pub mod binance;
 pub mod coinbase;
 
-use crate::{agent::Agent, config::Settings};
+use crate::{agent::Agent, config::Settings, error::IngestorError};
 use canonicalizer::CanonicalService;
 use std::collections::HashMap;
 
-async fn shared_symbols(
-) -> Result<(Vec<String>, Vec<String>), Box<dyn std::error::Error + Send + Sync>> {
+async fn shared_symbols() -> Result<(Vec<String>, Vec<String>), IngestorError> {
     // Ensure that the canonicalizer has loaded the quote asset list before we
     // attempt any symbol comparisons.
     CanonicalService::init().await;

--- a/crypto-ingestor/src/error.rs
+++ b/crypto-ingestor/src/error.rs
@@ -1,0 +1,18 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum IngestorError {
+    #[error("HTTP request failed for {exchange} {symbol:?}: {source}")]
+    Http {
+        #[source]
+        source: reqwest::Error,
+        exchange: &'static str,
+        symbol: Option<String>,
+    },
+    #[error(transparent)]
+    Config(#[from] ::config::ConfigError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error("{0}")]
+    Other(String),
+}

--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -1,9 +1,11 @@
 mod agent;
 mod agents;
 mod config;
+mod error;
 mod http_client;
 
 use agents::{available_agents, make_agent};
+use error::IngestorError;
 use canonicalizer::CanonicalService;
 use clap::Parser;
 use config::{Cli, Settings};
@@ -13,7 +15,7 @@ use tokio::sync::mpsc;
 use tracing_subscriber::FmtSubscriber;
 
 #[tokio::main(flavor = "multi_thread")]
-async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn main() -> Result<(), IngestorError> {
     // logger
     let subscriber = FmtSubscriber::builder().with_target(false).finish();
     let _ = tracing::subscriber::set_global_default(subscriber);
@@ -52,7 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         }
         let status = build.status().await?;
         if !status.success() {
-            return Err("failed to build canonicalizer".into());
+            return Err(IngestorError::Other("failed to build canonicalizer".into()));
         }
     }
     let mut canon_child = Command::new(&canon_path)


### PR DESCRIPTION
## Summary
- add thiserror-based `IngestorError` enum
- switch agents and main to return `IngestorError`
- provide exchange context for HTTP failures

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68acbd2dc9a88323a8cdccca10ee8492