### PR TITLE
refactor: consolidate coinbase imports

### DIFF
--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -3,10 +3,10 @@ use rust_decimal::Decimal;
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
 
-use crate::{agent::Agent, config::Settings, error::IngestorError, http_client};
 use crate::{
     agent::Agent,
     config::Settings,
+    error::IngestorError,
     http_client,
     metrics::{ERRORS, RECONNECTS, TRADES_RECEIVED},
 };
@@ -14,11 +14,13 @@ use canonicalizer::CanonicalService;
 
 /// Fetch all tradable USD product IDs from Coinbase.
 pub async fn fetch_all_symbols() -> Result<Vec<String>, IngestorError> {
-    let client = http_client::builder().build().map_err(|e| IngestorError::Http {
-        source: e,
-        exchange: "coinbase",
-        symbol: None,
-    })?;
+    let client = http_client::builder()
+        .build()
+        .map_err(|e| IngestorError::Http {
+            source: e,
+            exchange: "coinbase",
+            symbol: None,
+        })?;
     let products: serde_json::Value = client
         .get("https://api.exchange.coinbase.com/products")
         .send()


### PR DESCRIPTION
## Summary
- consolidate coinbase agent imports into a single block

## Testing
- `cargo test` *(fails: unresolved imports in agents and binance module)*

------
https://chatgpt.com/codex/tasks/task_e_68acc472864c8323a21b4364fdf69952