### PR TITLE
Expose error and metrics modules in crypto-ingestor

### DIFF
--- a/crypto-ingestor/src/lib.rs
+++ b/crypto-ingestor/src/lib.rs
@@ -2,3 +2,5 @@ pub mod agent;
 pub mod agents;
 pub mod config;
 pub mod http_client;
+pub mod error;
+pub mod metrics;


### PR DESCRIPTION
## Summary
- expose `error` and `metrics` modules from `crypto-ingestor` crate

## Testing
- `cargo build -p ingestor` *(fails: name `http_client` is defined multiple times)*

------
https://chatgpt.com/codex/tasks/task_e_68acc4752ac48323ae3189d44646f4e1