### PR TITLE
Add analytics module for spread detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "analytics"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,8 +833,8 @@ dependencies = [
  "clap",
  "config",
  "futures-util",
- "metrics",
  "hyper",
+ "metrics",
  "once_cell",
  "prometheus",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crypto-ingestor",
     "canonicalizer",
+    "analytics",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This repository is organised as a Cargo workspace containing two crates:
 - `crypto-ingestor` – the main executable that spawns exchange agents.
 - `canonicalizer` – a standalone service crate providing a library and binary
   for converting exchange-specific symbols into a canonical `BASE-QUOTE` form.
+- `analytics` – consumes canonicalized trades, tracks latest prices per
+  exchange and emits spread events.
 
 ## Available agents
 
@@ -84,4 +86,22 @@ Fields:
 When either `binance:all` or `coinbase:all` agents are used, both exchanges
 subscribe only to USD-quoted pairs common to both platforms so their symbol
 sets align.
+
+## Analytics
+
+The `analytics` crate listens for canonicalized trade records, maintains the
+latest price per exchange for each symbol, and computes inter-exchange spreads.
+When a spread exceeds a configurable threshold it emits a JSON event and logs
+the potential arbitrage opportunity.
+
+Run it by piping canonicalized trades from the ingestor:
+
+```bash
+cargo run --release -- binance:btcusdt coinbase:BTC-USD | \
+    cargo run -p analytics -- 10
+```
+
+The numeric argument specifies the minimum spread before an event is produced.
+Consumers can also use the library directly via the channel returned from
+`analytics::spawn`.
 

--- a/analytics/Cargo.toml
+++ b/analytics/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "analytics"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["rt", "macros", "sync", "io-util", "io-std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
+chrono = { version = "0.4", features = ["clock"] }
+

--- a/analytics/src/lib.rs
+++ b/analytics/src/lib.rs
@@ -1,0 +1,110 @@
+use std::collections::HashMap;
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{broadcast, mpsc};
+use tracing::info;
+
+/// Trade record consumed by the analytics service.
+#[derive(Debug, Deserialize)]
+pub struct Trade {
+    /// Source exchange name.
+    pub agent: String,
+    /// Canonical `BASE-QUOTE` symbol.
+    #[serde(rename = "s")]
+    pub symbol: String,
+    /// Trade price as string.
+    #[serde(rename = "p")]
+    pub price: String,
+}
+
+/// Event emitted when a spread exceeds the configured threshold.
+#[derive(Debug, Clone, Serialize)]
+pub struct SpreadEvent {
+    pub symbol: String,
+    pub buy_exchange: String,
+    pub sell_exchange: String,
+    pub spread: f64,
+    pub timestamp: i64,
+}
+
+/// Spawn the analytics task.
+///
+/// Returns a [`mpsc::Sender`] accepting [`Trade`] messages and a
+/// [`broadcast::Receiver`] yielding [`SpreadEvent`] notifications.
+pub fn spawn(threshold: f64) -> (mpsc::Sender<Trade>, broadcast::Receiver<SpreadEvent>) {
+    let (tx, mut rx) = mpsc::channel::<Trade>(100);
+    let (event_tx, event_rx) = broadcast::channel(100);
+
+    tokio::spawn(async move {
+        let mut prices: HashMap<String, HashMap<String, f64>> = HashMap::new();
+
+        while let Some(trade) = rx.recv().await {
+            if let Ok(price) = trade.price.parse::<f64>() {
+                let sym = trade.symbol.clone();
+                let exch = trade.agent.clone();
+                let entry = prices.entry(sym.clone()).or_default();
+                entry.insert(exch.clone(), price);
+
+                if entry.len() >= 2 {
+                    let mut best_buy: Option<(String, f64)> = None;
+                    let mut best_sell: Option<(String, f64)> = None;
+                    for (e, p) in entry.iter() {
+                        if best_buy.as_ref().map_or(true, |(_, bp)| p < bp) {
+                            best_buy = Some((e.clone(), *p));
+                        }
+                        if best_sell.as_ref().map_or(true, |(_, sp)| p > sp) {
+                            best_sell = Some((e.clone(), *p));
+                        }
+                    }
+                    if let (Some((buy_ex, buy_p)), Some((sell_ex, sell_p))) = (best_buy, best_sell)
+                    {
+                        let spread = sell_p - buy_p;
+                        if spread >= threshold {
+                            let event = SpreadEvent {
+                                symbol: sym.clone(),
+                                buy_exchange: buy_ex,
+                                sell_exchange: sell_ex,
+                                spread,
+                                timestamp: Utc::now().timestamp_millis(),
+                            };
+                            let _ = event_tx.send(event.clone());
+                            info!(?event, "arbitrage opportunity");
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    (tx, event_rx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn emits_spread_events() {
+        let (tx, mut rx) = spawn(10.0);
+        tx.send(Trade {
+            agent: "a".into(),
+            symbol: "BTC-USD".into(),
+            price: "100".into(),
+        })
+        .await
+        .unwrap();
+        tx.send(Trade {
+            agent: "b".into(),
+            symbol: "BTC-USD".into(),
+            price: "115".into(),
+        })
+        .await
+        .unwrap();
+        let ev = rx.recv().await.unwrap();
+        assert_eq!(ev.symbol, "BTC-USD");
+        assert_eq!(ev.buy_exchange, "a");
+        assert_eq!(ev.sell_exchange, "b");
+        assert!(ev.spread >= 15.0 - 1e-6);
+    }
+}

--- a/analytics/src/main.rs
+++ b/analytics/src/main.rs
@@ -1,0 +1,45 @@
+use analytics::{spawn, Trade};
+use serde_json::Value;
+use tokio::io::{self, AsyncBufReadExt};
+use tracing_subscriber::FmtSubscriber;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let subscriber = FmtSubscriber::builder().with_target(false).finish();
+    let _ = tracing::subscriber::set_global_default(subscriber);
+
+    let threshold = std::env::args()
+        .nth(1)
+        .and_then(|s| s.parse::<f64>().ok())
+        .unwrap_or(1.0);
+
+    let (tx, mut rx) = spawn(threshold);
+
+    // Task to read canonicalized trades from STDIN and forward to analytics
+    tokio::spawn(async move {
+        let stdin = io::BufReader::new(io::stdin());
+        let mut lines = stdin.lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<Value>(&line) {
+                Ok(v) => {
+                    if let Ok(trade) = serde_json::from_value::<Trade>(v) {
+                        let _ = tx.send(trade).await;
+                    }
+                }
+                Err(_) => {
+                    // ignore malformed input
+                }
+            }
+        }
+    });
+
+    // Print spread events as JSON lines
+    while let Ok(event) = rx.recv().await {
+        println!("{}", serde_json::to_string(&event)?);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `analytics` crate to track prices and emit spread events
- stream canonicalized trades into analytics via channel
- document analytics usage in README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ad05d7df748323bf5d4101946edf9b