### PR TITLE
Add pluggable output sinks for crypto-ingestor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,10 +821,11 @@ dependencies = [
  "clap",
  "config",
  "futures-util",
- "metrics",
  "hyper",
+ "metrics",
  "once_cell",
  "prometheus",
+ "rdkafka",
  "reqwest",
  "rust_decimal",
  "serde",
@@ -897,6 +898,18 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -1013,6 +1026,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1144,6 +1179,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,6 +1310,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rdkafka"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1beea247b9a7600a81d4cc33f659ce1a77e1988323d7d2809c7ed1c21f4c316d"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.9.0+2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5230dca48bc354d718269f3e4353280e188b610f7af7e2fcf54b7a79d5802872"
+dependencies = [
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2081,6 +2152,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/crypto-ingestor/Cargo.toml
+++ b/crypto-ingestor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 default-run = "ingestor"
 
 [dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "io-util", "process", "io-std"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "io-util", "process", "io-std", "fs"] }
 tokio-tungstenite = { version = "0.21", features = ["rustls-tls-webpki-roots"] }
 futures-util = "0.3"
 serde_json = "1"
@@ -27,6 +27,7 @@ config = "0.13"
 rust_decimal = "1"
 thiserror = "1"
 metrics_core = { package = "metrics", version = "0.21" }
+rdkafka = { version = "0.36", features = ["tokio"] }
 
 [profile.release]
 opt-level = 3

--- a/crypto-ingestor/src/lib.rs
+++ b/crypto-ingestor/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod agents;
 pub mod config;
-pub mod http_client;
 pub mod error;
+pub mod http_client;
+pub mod sink;
 pub mod telemetry;

--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -4,13 +4,16 @@ mod config;
 mod error;
 mod http_client;
 extern crate metrics_core as metrics;
+mod sink;
 mod telemetry;
 
 use agents::{available_agents, make_agent};
-use error::IngestorError;
 use canonicalizer::CanonicalService;
 use clap::Parser;
 use config::{Cli, Settings};
+use error::IngestorError;
+use sink::{DynSink, FileSink, KafkaSink, StdoutSink};
+use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use tokio::sync::mpsc;
@@ -41,6 +44,35 @@ async fn main() -> Result<(), IngestorError> {
     // metrics server
     tokio::spawn(telemetry::serve(([0, 0, 0, 0], 9898).into()));
 
+    // initialise output sink
+    let sink: DynSink = match settings.sink.as_str() {
+        "stdout" => Arc::new(StdoutSink::new()),
+        "file" => {
+            let path = settings
+                .file_path
+                .as_ref()
+                .ok_or_else(|| IngestorError::Other("file_path not set".into()))?;
+            Arc::new(FileSink::new(path).await.map_err(IngestorError::Io)?)
+        }
+        "kafka" => {
+            let brokers = settings
+                .kafka_brokers
+                .as_ref()
+                .ok_or_else(|| IngestorError::Other("kafka_brokers not set".into()))?;
+            let topic = settings
+                .kafka_topic
+                .as_ref()
+                .ok_or_else(|| IngestorError::Other("kafka_topic not set".into()))?;
+            Arc::new(KafkaSink::new(brokers, topic)?)
+        }
+        other => {
+            return Err(IngestorError::Other(format!(
+                "unknown sink type: {}",
+                other
+            )));
+        }
+    };
+
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
     // spawn canonicalizer process
@@ -66,6 +98,7 @@ async fn main() -> Result<(), IngestorError> {
 
     // spawn watchdog for canonicalizer process
     let canon_path_clone = canon_path.clone();
+    let sink_clone = sink.clone();
     let canon_watchdog = tokio::spawn(async move {
         let mut rx = rx;
         loop {
@@ -84,7 +117,7 @@ async fn main() -> Result<(), IngestorError> {
             let mut canon_stdin = canon_child.stdin.take().expect("canonicalizer stdin");
             let canon_stdout = canon_child.stdout.take().expect("canonicalizer stdout");
             let mut reader = tokio::io::BufReader::new(canon_stdout).lines();
-            let mut out = tokio::io::stdout();
+            let sink = sink_clone.clone();
 
             loop {
                 tokio::select! {
@@ -107,8 +140,9 @@ async fn main() -> Result<(), IngestorError> {
                     res = reader.next_line() => {
                         match res {
                             Ok(Some(line)) => {
-                                let _ = out.write_all(line.as_bytes()).await;
-                                let _ = out.write_all(b"\n").await;
+                                if let Err(e) = sink.send(&line).await {
+                                    tracing::error!(error=%e, "sink error");
+                                }
                             }
                             _ => break,
                         }

--- a/crypto-ingestor/src/sink.rs
+++ b/crypto-ingestor/src/sink.rs
@@ -1,0 +1,96 @@
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+
+use crate::error::IngestorError;
+
+#[async_trait]
+pub trait OutputSink: Send + Sync {
+    async fn send(&self, line: &str) -> Result<(), IngestorError>;
+}
+
+pub type DynSink = Arc<dyn OutputSink>;
+
+pub struct StdoutSink {
+    stdout: Mutex<tokio::io::Stdout>,
+}
+
+impl StdoutSink {
+    pub fn new() -> Self {
+        Self {
+            stdout: Mutex::new(tokio::io::stdout()),
+        }
+    }
+}
+
+#[async_trait]
+impl OutputSink for StdoutSink {
+    async fn send(&self, line: &str) -> Result<(), IngestorError> {
+        let mut stdout = self.stdout.lock().await;
+        stdout.write_all(line.as_bytes()).await?;
+        stdout.write_all(b"\n").await?;
+        Ok(())
+    }
+}
+
+pub struct FileSink {
+    file: Mutex<tokio::fs::File>,
+}
+
+impl FileSink {
+    pub async fn new(path: &str) -> Result<Self, std::io::Error> {
+        let file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .await?;
+        Ok(Self {
+            file: Mutex::new(file),
+        })
+    }
+}
+
+#[async_trait]
+impl OutputSink for FileSink {
+    async fn send(&self, line: &str) -> Result<(), IngestorError> {
+        let mut file = self.file.lock().await;
+        file.write_all(line.as_bytes()).await?;
+        file.write_all(b"\n").await?;
+        Ok(())
+    }
+}
+
+pub struct KafkaSink {
+    producer: rdkafka::producer::FutureProducer,
+    topic: String,
+}
+
+impl KafkaSink {
+    pub fn new(brokers: &str, topic: &str) -> Result<Self, IngestorError> {
+        use rdkafka::ClientConfig;
+        let producer: rdkafka::producer::FutureProducer = ClientConfig::new()
+            .set("bootstrap.servers", brokers)
+            .create()
+            .map_err(|e| IngestorError::Other(e.to_string()))?;
+        Ok(Self {
+            producer,
+            topic: topic.to_string(),
+        })
+    }
+}
+
+#[async_trait]
+impl OutputSink for KafkaSink {
+    async fn send(&self, line: &str) -> Result<(), IngestorError> {
+        use rdkafka::producer::FutureRecord;
+        self.producer
+            .send(
+                FutureRecord::to(&self.topic).payload(line).key(""),
+                std::time::Duration::from_secs(0),
+            )
+            .await
+            .map(|_| ())
+            .map_err(|(e, _)| IngestorError::Other(e.to_string()))
+    }
+}

--- a/crypto-ingestor/tests/ws.rs
+++ b/crypto-ingestor/tests/ws.rs
@@ -38,6 +38,7 @@ async fn coinbase_trade_messages_are_canonicalized_with_id() {
         binance_max_reconnect_delay_secs: 1,
         coinbase_ws_url: format!("ws://{}", addr),
         coinbase_max_reconnect_delay_secs: 1,
+        ..Default::default()
     };
 
     let mut agent = CoinbaseAgent::new(vec!["ETH-USD".into()], &cfg);
@@ -91,6 +92,7 @@ async fn binance_trade_messages_are_canonicalized_with_id() {
         binance_max_reconnect_delay_secs: 1,
         coinbase_ws_url: "ws://localhost".into(),
         coinbase_max_reconnect_delay_secs: 1,
+        ..Default::default()
     };
 
     let mut agent = BinanceAgent::new(Some(vec!["btcusdt".into()]), &cfg)


### PR DESCRIPTION
## Summary
- add `OutputSink` trait with stdout, file and Kafka implementations
- allow selecting sink type via CLI/config and dispatch canonicalized lines to it

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ad05d6e0f48323988424914ba3153c