### PR TITLE
Add default refresh interval for Coinbase

### DIFF
--- a/crypto-ingestor/src/config.rs
+++ b/crypto-ingestor/src/config.rs
@@ -59,6 +59,7 @@ impl Default for Settings {
             binance_refresh_interval_mins: 60,
             binance_max_reconnect_delay_secs: 30,
             coinbase_ws_url: String::new(),
+            coinbase_refresh_interval_mins: 60,
             coinbase_max_reconnect_delay_secs: 30,
             sink: default_sink(),
             kafka_brokers: None,


### PR DESCRIPTION
## Summary
- ensure Settings::default initializes `coinbase_refresh_interval_mins` with a sane value

## Testing
- `cargo build -p ingestor` *(fails: file not found for module `telemetry`)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0b9a0fb883239a002787593a9509