### PR TITLE
Remove telemetry module

### DIFF
--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -243,9 +243,8 @@ async fn connection_task(
                                         let _ = send_unsubscribe(&mut ws, &to_unsub).await;
                                     }
                                     if !to_sub.is_empty() {
-                                        if let Err(e) = send_subscribe(&mut ws, &to_sub).await {
+                                            if let Err(e) = send_subscribe(&mut ws, &to_sub).await {
                                             tracing::error!(error=%e, "failed to update subscription");
-                                            ERRORS.with_label_values(&["coinbase"]).inc();
                                             break;
                                         }
                                     }

--- a/crypto-ingestor/src/config.rs
+++ b/crypto-ingestor/src/config.rs
@@ -59,6 +59,7 @@ impl Default for Settings {
             binance_refresh_interval_mins: 60,
             binance_max_reconnect_delay_secs: 30,
             coinbase_ws_url: String::new(),
+            coinbase_refresh_interval_mins: 60,
             coinbase_max_reconnect_delay_secs: 30,
             sink: default_sink(),
             kafka_brokers: None,

--- a/crypto-ingestor/src/lib.rs
+++ b/crypto-ingestor/src/lib.rs
@@ -5,4 +5,3 @@ pub mod error;
 pub mod http_client;
 pub mod metrics;
 pub mod sink;
-pub mod telemetry;

--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -4,9 +4,7 @@ mod config;
 mod error;
 mod http_client;
 mod metrics;
-extern crate metrics_core as metrics;
 mod sink;
-mod telemetry;
 
 use agents::{available_agents, make_agent};
 use canonicalizer::CanonicalService;


### PR DESCRIPTION
## Summary
- drop unused telemetry module references from crypto-ingestor crate
- clean up leftover telemetry metric and add missing config default

## Testing
- `cargo build -p ingestor`


------
https://chatgpt.com/codex/tasks/task_e_68ad0b9821788323aee1338c308d4b89