### PR TITLE
Add errors metric for agent monitoring

### DIFF
--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     config::Settings,
     error::IngestorError,
     http_client,
-    metrics::{ACTIVE_CONNECTIONS, LAST_TRADE_TIMESTAMP, MESSAGES_INGESTED},
+    metrics::{ACTIVE_CONNECTIONS, ERRORS, LAST_TRADE_TIMESTAMP, MESSAGES_INGESTED},
 };
 use canonicalizer::CanonicalService;
 

--- a/crypto-ingestor/src/metrics.rs
+++ b/crypto-ingestor/src/metrics.rs
@@ -16,6 +16,10 @@ pub static MESSAGES_INGESTED: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!("errors_total", "Total number of errors", &["agent"]).unwrap()
+});
+
 pub static ACTIVE_CONNECTIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "active_connections",


### PR DESCRIPTION
## Summary
- track error counts per agent with new `ERRORS` metric
- import the errors metric in the Coinbase agent

## Testing
- `cargo build -p ingestor` *(fails: file not found for module `telemetry`; missing field `coinbase_refresh_interval_mins`)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0b99cd4883238937c4db760a2c66