### PR TITLE
feat: track coinbase errors

### DIFF
--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     config::Settings,
     error::IngestorError,
     http_client,
-    metrics::{ACTIVE_CONNECTIONS, LAST_TRADE_TIMESTAMP, MESSAGES_INGESTED},
+    metrics::{ACTIVE_CONNECTIONS, ERRORS, LAST_TRADE_TIMESTAMP, MESSAGES_INGESTED},
 };
 use canonicalizer::CanonicalService;
 

--- a/crypto-ingestor/src/config.rs
+++ b/crypto-ingestor/src/config.rs
@@ -59,6 +59,7 @@ impl Default for Settings {
             binance_refresh_interval_mins: 60,
             binance_max_reconnect_delay_secs: 30,
             coinbase_ws_url: String::new(),
+            coinbase_refresh_interval_mins: 60,
             coinbase_max_reconnect_delay_secs: 30,
             sink: default_sink(),
             kafka_brokers: None,

--- a/crypto-ingestor/src/lib.rs
+++ b/crypto-ingestor/src/lib.rs
@@ -5,4 +5,3 @@ pub mod error;
 pub mod http_client;
 pub mod metrics;
 pub mod sink;
-pub mod telemetry;

--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -4,9 +4,7 @@ mod config;
 mod error;
 mod http_client;
 mod metrics;
-extern crate metrics_core as metrics;
 mod sink;
-mod telemetry;
 
 use agents::{available_agents, make_agent};
 use canonicalizer::CanonicalService;

--- a/crypto-ingestor/src/metrics.rs
+++ b/crypto-ingestor/src/metrics.rs
@@ -34,6 +34,10 @@ pub static LAST_TRADE_TIMESTAMP: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!("errors_total", "Total number of errors", &["agent"]).unwrap()
+});
+
 pub static CANONICALIZER_RESTARTS: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
         "canonicalizer_restarts_total",


### PR DESCRIPTION
## Summary
- import ERRORS metric into Coinbase agent and expose counter
- remove telemetry references and fix configuration defaults

## Testing
- `cargo test -p ingestor`


------
https://chatgpt.com/codex/tasks/task_e_68ad0b9b291c8323a9f781dbb4ac46b3