### PR TITLE
Remove unused telemetry module and add error metric

### DIFF
--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     config::Settings,
     error::IngestorError,
     http_client,
-    metrics::{ACTIVE_CONNECTIONS, LAST_TRADE_TIMESTAMP, MESSAGES_INGESTED},
+    metrics::{ACTIVE_CONNECTIONS, ERRORS, LAST_TRADE_TIMESTAMP, MESSAGES_INGESTED},
 };
 use canonicalizer::CanonicalService;
 

--- a/crypto-ingestor/src/lib.rs
+++ b/crypto-ingestor/src/lib.rs
@@ -5,4 +5,3 @@ pub mod error;
 pub mod http_client;
 pub mod metrics;
 pub mod sink;
-pub mod telemetry;

--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -4,9 +4,7 @@ mod config;
 mod error;
 mod http_client;
 mod metrics;
-extern crate metrics_core as metrics;
 mod sink;
-mod telemetry;
 
 use agents::{available_agents, make_agent};
 use canonicalizer::CanonicalService;

--- a/crypto-ingestor/src/metrics.rs
+++ b/crypto-ingestor/src/metrics.rs
@@ -34,6 +34,10 @@ pub static LAST_TRADE_TIMESTAMP: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!("errors_total", "Total number of errors", &["agent"]).unwrap()
+});
+
 pub static CANONICALIZER_RESTARTS: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
         "canonicalizer_restarts_total",


### PR DESCRIPTION
## Summary
- remove unused `telemetry` module
- track agent errors with new `ERRORS` metric
- fix Coinbase agent to import `ERRORS` metric

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68ad0d3aa6d883239267383337d09def