### PR TITLE
feat: share decimal parsing across agents

### DIFF
--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -1,5 +1,4 @@
 use futures_util::{SinkExt, StreamExt};
-use rust_decimal::Decimal;
 use std::collections::HashSet;
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
@@ -10,6 +9,7 @@ use crate::{
     error::IngestorError,
     http_client,
     metrics::{ACTIVE_CONNECTIONS, LAST_TRADE_TIMESTAMP, MESSAGES_INGESTED},
+    parse::parse_decimal_str,
 };
 
 use super::{shared_symbols, AgentFactory};
@@ -64,12 +64,6 @@ pub async fn fetch_all_symbols() -> Result<Vec<String>, IngestorError> {
         .collect();
 
     Ok(symbols)
-}
-
-fn parse_decimal_str(s: &str) -> Option<String> {
-    s.parse::<Decimal>()
-        .ok()
-        .map(|d| d.round_dp(28).normalize().to_string())
 }
 
 pub struct BinanceAgent {

--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -1,5 +1,4 @@
 use futures_util::{SinkExt, StreamExt};
-use rust_decimal::Decimal;
 use std::collections::HashSet;
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
@@ -10,7 +9,8 @@ use crate::{
     config::Settings,
     error::IngestorError,
     http_client,
-    metrics::{ACTIVE_CONNECTIONS, ERRORS, LAST_TRADE_TIMESTAMP, MESSAGES_INGESTED},
+    metrics::{ACTIVE_CONNECTIONS, LAST_TRADE_TIMESTAMP, MESSAGES_INGESTED},
+    parse::parse_decimal_str,
 };
 use canonicalizer::CanonicalService;
 
@@ -52,12 +52,6 @@ pub async fn fetch_all_symbols() -> Result<Vec<String>, IngestorError> {
         }
     }
     Ok(symbols)
-}
-
-fn parse_decimal_str(s: &str) -> Option<String> {
-    s.parse::<Decimal>()
-        .ok()
-        .map(|d| d.round_dp(28).normalize().to_string())
 }
 
 pub struct CoinbaseAgent {

--- a/crypto-ingestor/src/lib.rs
+++ b/crypto-ingestor/src/lib.rs
@@ -4,4 +4,5 @@ pub mod config;
 pub mod error;
 pub mod http_client;
 pub mod metrics;
+pub mod parse;
 pub mod sink;

--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod error;
 mod http_client;
 mod metrics;
+mod parse;
 mod sink;
 
 use agents::{available_agents, make_agent};

--- a/crypto-ingestor/src/parse.rs
+++ b/crypto-ingestor/src/parse.rs
@@ -1,0 +1,10 @@
+use rust_decimal::Decimal;
+
+/// Parse a decimal string into a normalized representation.
+///
+/// The value is rounded to 28 decimal places and trailing zeros are removed.
+pub fn parse_decimal_str(s: &str) -> Option<String> {
+    s.parse::<Decimal>()
+        .ok()
+        .map(|d| d.round_dp(28).normalize().to_string())
+}


### PR DESCRIPTION
## Summary
- centralize decimal parsing in new `parse` module
- use shared `parse_decimal_str` in Binance and Coinbase agents

## Testing
- `cargo fmt`
- `cargo test -p ingestor`


------
https://chatgpt.com/codex/tasks/task_e_68ad0da1fbb0832390b675ef586feebe