### PR TITLE
refactor: centralize coinbase refresh interval default

### DIFF
--- a/crypto-ingestor/src/config.rs
+++ b/crypto-ingestor/src/config.rs
@@ -1,6 +1,9 @@
 use clap::Parser;
 use serde::Deserialize;
 
+/// Default refresh interval for the Coinbase websocket connection.
+pub const DEFAULT_COINBASE_REFRESH_INTERVAL_MINS: u64 = 60;
+
 /// Command line arguments
 #[derive(Parser, Debug, Clone)]
 #[command(author, version, about, long_about = None)]
@@ -59,7 +62,7 @@ impl Default for Settings {
             binance_refresh_interval_mins: 60,
             binance_max_reconnect_delay_secs: 30,
             coinbase_ws_url: String::new(),
-            coinbase_refresh_interval_mins: 60,
+            coinbase_refresh_interval_mins: DEFAULT_COINBASE_REFRESH_INTERVAL_MINS,
             coinbase_max_reconnect_delay_secs: 30,
             sink: default_sink(),
             kafka_brokers: None,
@@ -76,7 +79,10 @@ impl Settings {
             .set_default("binance_refresh_interval_mins", 60)?
             .set_default("binance_max_reconnect_delay_secs", 30)?
             .set_default("coinbase_ws_url", "wss://ws-feed.exchange.coinbase.com")?
-            .set_default("coinbase_refresh_interval_mins", 60)?
+            .set_default(
+                "coinbase_refresh_interval_mins",
+                DEFAULT_COINBASE_REFRESH_INTERVAL_MINS,
+            )?
             .set_default("coinbase_max_reconnect_delay_secs", 30)?
             .set_default("sink", "stdout")?
             .add_source(config::Environment::with_prefix("INGESTOR").separator("_"));

--- a/crypto-ingestor/tests/ws.rs
+++ b/crypto-ingestor/tests/ws.rs
@@ -6,7 +6,7 @@ use tokio_tungstenite::{accept_async, tungstenite::Message};
 
 use ingestor::agent::Agent;
 use ingestor::agents::{binance::BinanceAgent, coinbase::CoinbaseAgent};
-use ingestor::config::Settings;
+use ingestor::config::{Settings, DEFAULT_COINBASE_REFRESH_INTERVAL_MINS};
 
 #[tokio::test]
 async fn coinbase_trade_messages_are_canonicalized_with_id() {
@@ -37,7 +37,7 @@ async fn coinbase_trade_messages_are_canonicalized_with_id() {
         binance_refresh_interval_mins: 60,
         binance_max_reconnect_delay_secs: 1,
         coinbase_ws_url: format!("ws://{}", addr),
-        coinbase_refresh_interval_mins: 60,
+        coinbase_refresh_interval_mins: DEFAULT_COINBASE_REFRESH_INTERVAL_MINS,
         coinbase_max_reconnect_delay_secs: 1,
         ..Default::default()
     };
@@ -92,7 +92,7 @@ async fn binance_trade_messages_are_canonicalized_with_id() {
         binance_refresh_interval_mins: 60,
         binance_max_reconnect_delay_secs: 1,
         coinbase_ws_url: "ws://localhost".into(),
-        coinbase_refresh_interval_mins: 60,
+        coinbase_refresh_interval_mins: DEFAULT_COINBASE_REFRESH_INTERVAL_MINS,
         coinbase_max_reconnect_delay_secs: 1,
         ..Default::default()
     };


### PR DESCRIPTION
## Summary
- define constant for Coinbase refresh interval
- use the constant in Settings default configuration
- update websocket tests to reference the constant

## Testing
- `cargo check` *(fails: file not found for module `telemetry`; cannot find value `ERRORS`)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0d3b497083238f4834ac89b0f7db