### PR TITLE
Fix duplicate ERRORS metric definition

### DIFF
--- a/crypto-ingestor/src/metrics.rs
+++ b/crypto-ingestor/src/metrics.rs
@@ -38,10 +38,6 @@ pub static LAST_TRADE_TIMESTAMP: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!("errors_total", "Total number of errors", &["agent"]).unwrap()
-});
-
 pub static CANONICALIZER_RESTARTS: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
         "canonicalizer_restarts_total",


### PR DESCRIPTION
## Summary
- remove duplicate ERRORS counter from metrics module

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ad1b0e9b90832382bd7d434cba8c9b