### PR TITLE
Remove unused agent registration and error metric

### DIFF
--- a/crypto-ingestor/src/agents/mod.rs
+++ b/crypto-ingestor/src/agents/mod.rs
@@ -20,10 +20,6 @@ pub static AGENT_FACTORIES: Lazy<Mutex<HashMap<&'static str, Box<dyn AgentFactor
         Mutex::new(m)
     });
 
-pub fn register_agent(name: &'static str, factory: Box<dyn AgentFactory>) {
-    AGENT_FACTORIES.lock().unwrap().insert(name, factory);
-}
-
 async fn shared_symbols() -> Result<(Vec<String>, Vec<String>), IngestorError> {
     // Ensure that the canonicalizer has loaded the quote asset list before we
     // attempt any symbol comparisons.

--- a/crypto-ingestor/src/metrics.rs
+++ b/crypto-ingestor/src/metrics.rs
@@ -16,10 +16,6 @@ pub static MESSAGES_INGESTED: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!("errors_total", "Total number of errors", &["agent"]).unwrap()
-});
-
 pub static ACTIVE_CONNECTIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "active_connections",


### PR DESCRIPTION
## Summary
- remove unused `register_agent` helper that caused dead code warnings
- drop unused `ERRORS` counter from metrics module

## Testing
- `cargo test -p ingestor`


------
https://chatgpt.com/codex/tasks/task_e_68ad1cc498c8832382b07d872a9c508c