### PR TITLE
Add macro data service for macro metrics and crypto indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,7 +633,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -1002,6 +1002,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "macro-data"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1025,28 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "metrics"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+dependencies = [
+ "ahash 0.8.12",
+ "metrics-macros",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "mime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crypto-ingestor",
     "canonicalizer",
     "analytics",
+    "macro-data",
 ]
 resolver = "2"
 

--- a/macro-data/Cargo.toml
+++ b/macro-data/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "macro-data"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"] }
+reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+chrono = { version = "0.4", features = ["clock"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "macro-data"
+path = "src/main.rs"

--- a/macro-data/src/lib.rs
+++ b/macro-data/src/lib.rs
@@ -1,0 +1,337 @@
+use std::collections::HashMap;
+
+use chrono::{NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+use tokio::time::{interval, Duration};
+use tracing::info;
+
+/// Generic macroeconomic metric emitted by the service.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MacroMetric {
+    pub category: String,
+    pub symbol: String,
+    pub value: f64,
+    pub timestamp: i64,
+}
+
+/// Index values calculated from cryptocurrency market data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CryptoIndex {
+    pub name: String,
+    pub value: f64,
+    pub timestamp: i64,
+}
+
+/// Spawn background tasks fetching macro data and crypto indices.
+///
+/// Returns [`broadcast::Receiver`]s yielding [`MacroMetric`] and [`CryptoIndex`] events.
+pub fn spawn() -> (broadcast::Receiver<MacroMetric>, broadcast::Receiver<CryptoIndex>) {
+    let (macro_tx, macro_rx) = broadcast::channel(100);
+    let (crypto_tx, crypto_rx) = broadcast::channel(100);
+
+    tokio::spawn(run_fx_fetcher(macro_tx.clone()));
+    tokio::spawn(run_rates_fetcher(macro_tx.clone()));
+    tokio::spawn(run_commodity_fetcher(macro_tx.clone()));
+    tokio::spawn(run_equity_fetcher(macro_tx.clone()));
+    tokio::spawn(run_event_fetcher(macro_tx.clone()));
+    tokio::spawn(run_crypto_indices_fetcher(crypto_tx.clone()));
+
+    (macro_rx, crypto_rx)
+}
+
+async fn run_fx_fetcher(tx: broadcast::Sender<MacroMetric>) {
+    let client = reqwest::Client::new();
+    let mut intv = interval(Duration::from_secs(3600));
+    loop {
+        intv.tick().await;
+        match client
+            .get("https://api.exchangerate.host/latest?base=USD&symbols=EUR,JPY,GBP")
+            .send()
+            .await
+        {
+            Ok(resp) => match resp.text().await {
+                Ok(body) => match parse_exchangerate_host(&body) {
+                    Ok(metrics) => metrics.into_iter().for_each(|m| {
+                        let _ = tx.send(m);
+                    }),
+                    Err(e) => info!("fx parse error: {}", e),
+                },
+                Err(e) => info!("fx body error: {}", e),
+            },
+            Err(e) => info!("fx fetch error: {}", e),
+        }
+    }
+}
+
+async fn run_rates_fetcher(tx: broadcast::Sender<MacroMetric>) {
+    let api_key = match std::env::var("FRED_API_KEY") {
+        Ok(k) => k,
+        Err(_) => {
+            info!("FRED_API_KEY not set; disabling rate fetcher");
+            return;
+        }
+    };
+    let client = reqwest::Client::new();
+    let mut intv = interval(Duration::from_secs(3600));
+    loop {
+        intv.tick().await;
+        let url = format!("https://api.stlouisfed.org/fred/series/observations?series_id=DGS10&sort_order=desc&limit=1&api_key={}&file_type=json", api_key);
+        match client.get(&url).send().await {
+            Ok(resp) => match resp.text().await {
+                Ok(body) => match parse_fred_rate(&body) {
+                    Ok(Some(val)) => {
+                        let metric = MacroMetric {
+                            category: "rate".into(),
+                            symbol: "US10Y".into(),
+                            value: val,
+                            timestamp: Utc::now().timestamp_millis(),
+                        };
+                        let _ = tx.send(metric);
+                    }
+                    Ok(None) => info!("no rate data"),
+                    Err(e) => info!("rate parse error: {}", e),
+                },
+                Err(e) => info!("rate body error: {}", e),
+            },
+            Err(e) => info!("rate fetch error: {}", e),
+        }
+    }
+}
+
+async fn run_commodity_fetcher(tx: broadcast::Sender<MacroMetric>) {
+    let client = reqwest::Client::new();
+    let mut intv = interval(Duration::from_secs(3600));
+    loop {
+        intv.tick().await;
+        for (symbol, name) in [("gc.f", "GOLD"), ("cl.f", "WTI")] {
+            if let Ok(resp) = client
+                .get(format!("https://stooq.com/q/l/?s={}&i=d", symbol))
+                .send()
+                .await
+            {
+                if let Ok(body) = resp.text().await {
+                    if let Some(price) = parse_stooq_price(&body) {
+                        let metric = MacroMetric {
+                            category: "commodity".into(),
+                            symbol: name.into(),
+                            value: price,
+                            timestamp: Utc::now().timestamp_millis(),
+                        };
+                        let _ = tx.send(metric);
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn run_equity_fetcher(tx: broadcast::Sender<MacroMetric>) {
+    let client = reqwest::Client::new();
+    let mut intv = interval(Duration::from_secs(3600));
+    loop {
+        intv.tick().await;
+        for (symbol, name) in [("^spx", "SPX"), ("^ndq", "NDQ"), ("^dji", "DJI")] {
+            if let Ok(resp) = client
+                .get(format!("https://stooq.com/q/l/?s={}&i=d", symbol))
+                .send()
+                .await
+            {
+                if let Ok(body) = resp.text().await {
+                    if let Some(level) = parse_stooq_price(&body) {
+                        let metric = MacroMetric {
+                            category: "equity".into(),
+                            symbol: name.into(),
+                            value: level,
+                            timestamp: Utc::now().timestamp_millis(),
+                        };
+                        let _ = tx.send(metric);
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn run_event_fetcher(tx: broadcast::Sender<MacroMetric>) {
+    let client = reqwest::Client::new();
+    let mut intv = interval(Duration::from_secs(86400));
+    loop {
+        intv.tick().await;
+        match client
+            .get("https://date.nager.at/api/v3/NextPublicHolidays/US")
+            .send()
+            .await
+        {
+            Ok(resp) => match resp.text().await {
+                Ok(body) => match parse_nager_events(&body) {
+                    Ok(events) => events.into_iter().for_each(|e| {
+                        let _ = tx.send(e);
+                    }),
+                    Err(e) => info!("event parse error: {}", e),
+                },
+                Err(e) => info!("event body error: {}", e),
+            },
+            Err(e) => info!("event fetch error: {}", e),
+        }
+    }
+}
+
+async fn run_crypto_indices_fetcher(tx: broadcast::Sender<CryptoIndex>) {
+    let client = reqwest::Client::new();
+    let mut intv = interval(Duration::from_secs(300));
+    loop {
+        intv.tick().await;
+        match client
+            .get("https://api.coingecko.com/api/v3/global")
+            .send()
+            .await
+        {
+            Ok(resp) => match resp.text().await {
+                Ok(body) => match parse_coingecko_global(&body) {
+                    Ok(indices) => indices.into_iter().for_each(|i| {
+                        let _ = tx.send(i);
+                    }),
+                    Err(e) => info!("crypto index parse error: {}", e),
+                },
+                Err(e) => info!("crypto index body error: {}", e),
+            },
+            Err(e) => info!("crypto index fetch error: {}", e),
+        }
+    }
+}
+
+fn parse_exchangerate_host(data: &str) -> Result<Vec<MacroMetric>, serde_json::Error> {
+    #[derive(Deserialize)]
+    struct Resp {
+        base: String,
+        rates: HashMap<String, f64>,
+    }
+    let resp: Resp = serde_json::from_str(data)?;
+    let ts = Utc::now().timestamp_millis();
+    Ok(resp
+        .rates
+        .into_iter()
+        .map(|(sym, rate)| MacroMetric {
+            category: "fx".into(),
+            symbol: format!("{}{}", resp.base, sym),
+            value: rate,
+            timestamp: ts,
+        })
+        .collect())
+}
+
+fn parse_coingecko_global(data: &str) -> Result<Vec<CryptoIndex>, serde_json::Error> {
+    #[derive(Deserialize)]
+    struct Data {
+        market_cap_percentage: HashMap<String, f64>,
+    }
+    #[derive(Deserialize)]
+    struct Resp {
+        data: Data,
+    }
+    let resp: Resp = serde_json::from_str(data)?;
+    let ts = Utc::now().timestamp_millis();
+    let mut res = Vec::new();
+    if let Some(btc) = resp.data.market_cap_percentage.get("btc") {
+        res.push(CryptoIndex {
+            name: "btc_dominance".into(),
+            value: *btc,
+            timestamp: ts,
+        });
+    }
+    if let Some(eth) = resp.data.market_cap_percentage.get("eth") {
+        res.push(CryptoIndex {
+            name: "eth_dominance".into(),
+            value: *eth,
+            timestamp: ts,
+        });
+    }
+    Ok(res)
+}
+
+fn parse_fred_rate(data: &str) -> Result<Option<f64>, serde_json::Error> {
+    #[derive(Deserialize)]
+    struct Obs {
+        value: String,
+    }
+    #[derive(Deserialize)]
+    struct Resp {
+        observations: Vec<Obs>,
+    }
+    let resp: Resp = serde_json::from_str(data)?;
+    if let Some(o) = resp.observations.get(0) {
+        if let Ok(v) = o.value.parse::<f64>() {
+            return Ok(Some(v));
+        }
+    }
+    Ok(None)
+}
+
+fn parse_stooq_price(data: &str) -> Option<f64> {
+    data.split(',').nth(6)?.parse().ok()
+}
+
+fn parse_nager_events(data: &str) -> Result<Vec<MacroMetric>, serde_json::Error> {
+    #[derive(Deserialize)]
+    struct Holiday {
+        date: String,
+        name: String,
+    }
+    let holidays: Vec<Holiday> = serde_json::from_str(data)?;
+    let mut res = Vec::new();
+    for h in holidays {
+        if let Ok(d) = NaiveDate::parse_from_str(&h.date, "%Y-%m-%d") {
+            let ts = d
+                .and_hms_opt(0, 0, 0)
+                .unwrap()
+                .and_utc()
+                .timestamp_millis();
+            res.push(MacroMetric {
+                category: "event".into(),
+                symbol: h.name,
+                value: 1.0,
+                timestamp: ts,
+            });
+        }
+    }
+    Ok(res)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_fx_rates() {
+        let json = r#"{"base":"USD","rates":{"EUR":0.9,"JPY":110.0}}"#;
+        let metrics = parse_exchangerate_host(json).unwrap();
+        assert_eq!(metrics.len(), 2);
+        assert!(metrics.iter().any(|m| m.symbol == "USDEUR" && (m.value - 0.9).abs() < 1e-6));
+        assert!(metrics.iter().any(|m| m.symbol == "USDJPY" && (m.value - 110.0).abs() < 1e-6));
+    }
+
+    #[test]
+    fn parses_crypto_indices() {
+        let json = r#"{"data":{"market_cap_percentage":{"btc":51.0,"eth":18.0}}}"#;
+        let indices = parse_coingecko_global(json).unwrap();
+        assert!(indices.iter().any(|i| i.name == "btc_dominance" && (i.value - 51.0).abs() < 1e-6));
+        assert!(indices.iter().any(|i| i.name == "eth_dominance" && (i.value - 18.0).abs() < 1e-6));
+    }
+
+    #[test]
+    fn parses_stooq() {
+        let line = "^SPX,20250825,230000,6457.67,6466.89,6438.06,6439.32,2506639696,";
+        let price = parse_stooq_price(line).unwrap();
+        assert!((price - 6439.32).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parses_events() {
+        let json = r#"[{"date":"2025-09-01","name":"Labor Day"}]"#;
+        let events = parse_nager_events(json).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].symbol, "Labor Day");
+        assert_eq!(events[0].category, "event");
+    }
+}

--- a/macro-data/src/main.rs
+++ b/macro-data/src/main.rs
@@ -1,0 +1,15 @@
+use macro_data::spawn;
+use tokio::signal;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    let (mut macro_rx, mut crypto_rx) = spawn();
+    loop {
+        tokio::select! {
+            Ok(metric) = macro_rx.recv() => println!("macro: {:?}", metric),
+            Ok(index) = crypto_rx.recv() => println!("crypto: {:?}", index),
+            _ = signal::ctrl_c() => break,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `macro-data` crate to pull public FX, rates, commodity, equity, holiday, and crypto data
- emit `MacroMetric` and `CryptoIndex` events on a schedule

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ad1ff9b768832383b1ac06e7404ceb