### PR TITLE
Document feature flags and canonicalization tests for upcoming events

### DIFF
--- a/crypto-ingestor/tests/new_events.rs
+++ b/crypto-ingestor/tests/new_events.rs
@@ -1,0 +1,72 @@
+use canonicalizer::CanonicalService;
+use serde_json::json;
+use std::sync::Once;
+
+async fn canonicalize(exchange: &str, symbol: &str) -> String {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        std::env::set_var("BINANCE_QUOTES", "usdt,usdc,busd,usd,btc,eth,bnb");
+    });
+    CanonicalService::init().await;
+    CanonicalService::canonical_pair(exchange, symbol).unwrap()
+}
+
+#[tokio::test]
+async fn options_chain_event_is_canonicalized() {
+    let canon = canonicalize("binance", "btcusdt").await;
+    let event = json!({
+        "agent": "binance",
+        "type": "options_chain",
+        "s": canon,
+        "strike": "30000",
+        "expiry": "2024-12-31T00:00:00Z",
+        "option_type": "call",
+        "p": "100.00",
+        "q": "0.01",
+        "ts": 0
+    });
+    assert_eq!(event["s"], "BTC-USDT");
+}
+
+#[tokio::test]
+async fn mempool_event_is_canonicalized() {
+    let canon = canonicalize("binance", "ethbtc").await;
+    let event = json!({
+        "agent": "binance",
+        "type": "mempool",
+        "s": canon,
+        "hash": "0x",
+        "value": "1.0",
+        "ts": 0
+    });
+    assert_eq!(event["s"], "ETH-BTC");
+}
+
+#[tokio::test]
+async fn bridge_flow_event_is_canonicalized() {
+    let canon = canonicalize("binance", "bnbeth").await;
+    let event = json!({
+        "agent": "binance",
+        "type": "bridge_flow",
+        "s": canon,
+        "amount": "10",
+        "from_chain": "bsc",
+        "to_chain": "eth",
+        "ts": 0
+    });
+    assert_eq!(event["s"], "BNB-ETH");
+}
+
+#[tokio::test]
+async fn mev_signal_event_is_canonicalized() {
+    let canon = canonicalize("binance", "adausdt").await;
+    let event = json!({
+        "agent": "binance",
+        "type": "mev_signal",
+        "s": canon,
+        "strategy": "arbitrage",
+        "profit": "5.0",
+        "ts": 0
+    });
+    assert_eq!(event["s"], "ADA-USDT");
+}

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,83 @@
+# Feature Flags and Event Schemas
+
+Feature flags allow iterative development of new data sources. The following phases are planned:
+
+1. Options Chain (`INGESTOR_ENABLE_OPTIONS`)
+2. Mempool (`INGESTOR_ENABLE_MEMPOOL`)
+3. Bridge Flows (`INGESTOR_ENABLE_BRIDGE`)
+4. MEV Signals (`INGESTOR_ENABLE_MEV`)
+
+
+## Options Chain (`INGESTOR_ENABLE_OPTIONS`)
+
+Enables ingestion of options chain data.
+
+Expected event schema:
+
+```json
+{
+  "agent": "exchange name",
+  "type": "options_chain",
+  "s": "BTC-USDT",
+  "strike": "30000",
+  "expiry": "2024-12-31T00:00:00Z",
+  "option_type": "call",
+  "p": "100.00",
+  "q": "0.01",
+  "ts": 0
+}
+```
+
+## Mempool (`INGESTOR_ENABLE_MEMPOOL`)
+
+Enables ingestion of mempool transaction events.
+
+Expected event schema:
+
+```json
+{
+  "agent": "network",
+  "type": "mempool",
+  "s": "ETH-BTC",
+  "hash": "0x...",
+  "value": "1.0",
+  "ts": 0
+}
+```
+
+## Bridge Flows (`INGESTOR_ENABLE_BRIDGE`)
+
+Monitors token transfers across chains.
+
+Expected event schema:
+
+```json
+{
+  "agent": "bridge",
+  "type": "bridge_flow",
+  "s": "BNB-ETH",
+  "amount": "10",
+  "from_chain": "bsc",
+  "to_chain": "eth",
+  "ts": 0
+}
+```
+
+## MEV Signals (`INGESTOR_ENABLE_MEV`)
+
+Surfacing miner-extractable value opportunities.
+
+Expected event schema:
+
+```json
+{
+  "agent": "searcher",
+  "type": "mev_signal",
+  "s": "ADA-USDT",
+  "strategy": "arbitrage",
+  "profit": "5.0",
+  "ts": 0
+}
+```
+
+Each event uses the `s` field for a canonical `BASE-QUOTE` symbol which will be normalized by the `canonicalizer` crate. These flags are placeholders intended to guide iterative development: enabling a flag will allow contributors to implement its corresponding data pipeline without affecting existing functionality.


### PR DESCRIPTION
## Summary
- document feature flags and event schemas for options chain, mempool, bridge flows, and MEV signals
- add integration tests exercising canonicalization for the new event types

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ad2003aa188323ad219d993676dc95