### PR TITLE
Add Phase 1 feed toggles and usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,33 @@ This repository is organised as a Cargo workspace containing two crates:
 - `binance` – streams trade data for selected symbols via WebSocket.
 - `coinbase` – streams trade data for selected pairs via WebSocket.
 
+## Phase 1 feeds
+
+`crypto-ingestor` can toggle a variety of market and auxiliary data streams at
+runtime. Each feed is enabled via a dedicated command-line flag:
+
+- `--trades` – raw trade data
+- `--l2-diffs` – incremental order book updates
+- `--l2-snapshots` – full order book snapshots
+- `--book-ticker` – best bid/ask updates
+- `--ticker-24h` – rolling 24‑hour ticker
+- `--ohlcv` – candlestick data
+- `--index-price` – index prices
+- `--mark-price` – futures mark prices
+- `--funding-rates` – funding rate changes
+- `--open-interest` – open interest statistics
+- `--onchain-transfers` – on-chain transfer activity
+- `--onchain-balances` – on-chain balance changes
+- `--top-dex-pools` – top DEX pool prices
+- `--news-headlines` – crypto news headlines
+- `--telemetry` – system telemetry events
+
+Example enabling trades and the 24h ticker:
+
+```bash
+cargo run --release -- --trades --ticker-24h binance:btcusdt
+```
+
 ## Metrics
 
 `crypto-ingestor` exposes Prometheus metrics and a health check on port `9898`.

--- a/crypto-ingestor/src/config.rs
+++ b/crypto-ingestor/src/config.rs
@@ -28,6 +28,66 @@ pub struct Cli {
     #[arg(long)]
     pub file_path: Option<String>,
 
+    /// Enable trade feeds
+    #[arg(long)]
+    pub trades: bool,
+
+    /// Enable level 2 diff order book feeds
+    #[arg(long)]
+    pub l2_diffs: bool,
+
+    /// Enable level 2 snapshot order book feeds
+    #[arg(long)]
+    pub l2_snapshots: bool,
+
+    /// Enable book ticker updates
+    #[arg(long)]
+    pub book_ticker: bool,
+
+    /// Enable rolling 24h ticker updates
+    #[arg(long)]
+    pub ticker_24h: bool,
+
+    /// Enable OHLCV candle data
+    #[arg(long)]
+    pub ohlcv: bool,
+
+    /// Enable index price feeds
+    #[arg(long)]
+    pub index_price: bool,
+
+    /// Enable mark price feeds
+    #[arg(long)]
+    pub mark_price: bool,
+
+    /// Enable funding rates
+    #[arg(long)]
+    pub funding_rates: bool,
+
+    /// Enable open interest data
+    #[arg(long)]
+    pub open_interest: bool,
+
+    /// Enable on-chain transfer feeds
+    #[arg(long)]
+    pub onchain_transfers: bool,
+
+    /// Enable on-chain balance feeds
+    #[arg(long)]
+    pub onchain_balances: bool,
+
+    /// Enable top DEX pool price feeds
+    #[arg(long)]
+    pub top_dex_pools: bool,
+
+    /// Enable news headline feeds
+    #[arg(long)]
+    pub news_headlines: bool,
+
+    /// Enable telemetry events
+    #[arg(long)]
+    pub telemetry: bool,
+
     /// Agent specifications (e.g. binance:btcusdt)
     pub specs: Vec<String>,
 }
@@ -49,6 +109,37 @@ pub struct Settings {
     pub kafka_topic: Option<String>,
     #[serde(default)]
     pub file_path: Option<String>,
+
+    #[serde(default)]
+    pub trades: bool,
+    #[serde(default)]
+    pub l2_diffs: bool,
+    #[serde(default)]
+    pub l2_snapshots: bool,
+    #[serde(default)]
+    pub book_ticker: bool,
+    #[serde(default)]
+    pub ticker_24h: bool,
+    #[serde(default)]
+    pub ohlcv: bool,
+    #[serde(default)]
+    pub index_price: bool,
+    #[serde(default)]
+    pub mark_price: bool,
+    #[serde(default)]
+    pub funding_rates: bool,
+    #[serde(default)]
+    pub open_interest: bool,
+    #[serde(default)]
+    pub onchain_transfers: bool,
+    #[serde(default)]
+    pub onchain_balances: bool,
+    #[serde(default)]
+    pub top_dex_pools: bool,
+    #[serde(default)]
+    pub news_headlines: bool,
+    #[serde(default)]
+    pub telemetry: bool,
 }
 
 fn default_sink() -> String {
@@ -68,6 +159,21 @@ impl Default for Settings {
             kafka_brokers: None,
             kafka_topic: None,
             file_path: None,
+            trades: false,
+            l2_diffs: false,
+            l2_snapshots: false,
+            book_ticker: false,
+            ticker_24h: false,
+            ohlcv: false,
+            index_price: false,
+            mark_price: false,
+            funding_rates: false,
+            open_interest: false,
+            onchain_transfers: false,
+            onchain_balances: false,
+            top_dex_pools: false,
+            news_headlines: false,
+            telemetry: false,
         }
     }
 }
@@ -85,6 +191,21 @@ impl Settings {
             )?
             .set_default("coinbase_max_reconnect_delay_secs", 30)?
             .set_default("sink", "stdout")?
+            .set_default("trades", false)?
+            .set_default("l2_diffs", false)?
+            .set_default("l2_snapshots", false)?
+            .set_default("book_ticker", false)?
+            .set_default("ticker_24h", false)?
+            .set_default("ohlcv", false)?
+            .set_default("index_price", false)?
+            .set_default("mark_price", false)?
+            .set_default("funding_rates", false)?
+            .set_default("open_interest", false)?
+            .set_default("onchain_transfers", false)?
+            .set_default("onchain_balances", false)?
+            .set_default("top_dex_pools", false)?
+            .set_default("news_headlines", false)?
+            .set_default("telemetry", false)?
             .add_source(config::Environment::with_prefix("INGESTOR").separator("_"));
         if let Some(path) = &cli.config {
             builder = builder.add_source(config::File::with_name(path));
@@ -101,6 +222,21 @@ impl Settings {
         if let Some(p) = &cli.file_path {
             settings.file_path = Some(p.clone());
         }
+        settings.trades = settings.trades || cli.trades;
+        settings.l2_diffs = settings.l2_diffs || cli.l2_diffs;
+        settings.l2_snapshots = settings.l2_snapshots || cli.l2_snapshots;
+        settings.book_ticker = settings.book_ticker || cli.book_ticker;
+        settings.ticker_24h = settings.ticker_24h || cli.ticker_24h;
+        settings.ohlcv = settings.ohlcv || cli.ohlcv;
+        settings.index_price = settings.index_price || cli.index_price;
+        settings.mark_price = settings.mark_price || cli.mark_price;
+        settings.funding_rates = settings.funding_rates || cli.funding_rates;
+        settings.open_interest = settings.open_interest || cli.open_interest;
+        settings.onchain_transfers = settings.onchain_transfers || cli.onchain_transfers;
+        settings.onchain_balances = settings.onchain_balances || cli.onchain_balances;
+        settings.top_dex_pools = settings.top_dex_pools || cli.top_dex_pools;
+        settings.news_headlines = settings.news_headlines || cli.news_headlines;
+        settings.telemetry = settings.telemetry || cli.telemetry;
         Ok(settings)
     }
 }


### PR DESCRIPTION
## Summary
- add per-feed configuration flags for trades, order book, ticker, funding and more
- document dynamic feed flags with example CLI invocation

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ad20013e4c8323a68128b5369eca11