### PR TITLE
Add Binance options polling and OptionChain normalization

### DIFF
--- a/canonicalizer/src/events.rs
+++ b/canonicalizer/src/events.rs
@@ -1,0 +1,83 @@
+use serde::{Deserialize, Serialize};
+
+/// Greeks associated with an option contract.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OptionGreeks {
+    /// Delta of the option.
+    pub delta: Option<f64>,
+    /// Gamma of the option.
+    pub gamma: Option<f64>,
+    /// Theta of the option.
+    pub theta: Option<f64>,
+    /// Vega of the option.
+    pub vega: Option<f64>,
+}
+
+/// Quoted data for a single option contract.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OptionQuote {
+    /// Strike price of the contract.
+    pub strike: f64,
+    /// Contract type: "CALL" or "PUT".
+    pub kind: String,
+    /// Bid price.
+    pub bid: Option<f64>,
+    /// Ask price.
+    pub ask: Option<f64>,
+    /// Last traded price.
+    pub last: Option<f64>,
+    /// Implied volatility as a ratio (e.g. 0.55 == 55%).
+    pub iv: Option<f64>,
+    /// Associated greeks for this option.
+    pub greeks: Option<OptionGreeks>,
+}
+
+/// Normalised representation of an option chain for a single expiry.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OptionChain {
+    /// Source agent or exchange.
+    pub agent: String,
+    /// Event type, always `"option_chain"` for this structure.
+    #[serde(rename = "type")]
+    pub r#type: String,
+    /// Canonical underlying symbol (e.g. `BTC-USDT`).
+    pub s: String,
+    /// Expiration timestamp (seconds since Unix epoch).
+    pub expiry: i64,
+    /// Collection of option quotes at this expiry.
+    pub options: Vec<OptionQuote>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn option_chain_serialises() {
+        let chain = OptionChain {
+            agent: "binance".into(),
+            r#type: "option_chain".into(),
+            s: "BTC-USD".into(),
+            expiry: 1_700_000_000,
+            options: vec![OptionQuote {
+                strike: 30000.0,
+                kind: "CALL".into(),
+                bid: Some(10.0),
+                ask: Some(11.0),
+                last: Some(10.5),
+                iv: Some(0.55),
+                greeks: Some(OptionGreeks {
+                    delta: Some(0.5),
+                    gamma: Some(0.1),
+                    theta: Some(-0.01),
+                    vega: Some(0.2),
+                }),
+            }],
+        };
+
+        let json = serde_json::to_string(&chain).expect("serialize");
+        let back: OptionChain = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, chain);
+    }
+}
+

--- a/canonicalizer/src/lib.rs
+++ b/canonicalizer/src/lib.rs
@@ -18,6 +18,9 @@
 //! [`CanonicalService::canonical_pair`].
 
 mod http_client;
+pub mod events;
+
+pub use events::{OptionChain, OptionGreeks, OptionQuote};
 
 use std::collections::HashSet;
 use std::sync::OnceLock;

--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -1,4 +1,5 @@
 use futures_util::{SinkExt, StreamExt};
+pub mod options;
 use std::collections::HashSet;
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};

--- a/crypto-ingestor/src/agents/binance/options.rs
+++ b/crypto-ingestor/src/agents/binance/options.rs
@@ -1,0 +1,188 @@
+use std::time::Duration;
+
+use canonicalizer::{CanonicalService, OptionChain, OptionGreeks, OptionQuote};
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+use crate::{agent::Agent, config::Settings, error::IngestorError, http_client};
+
+pub struct BinanceOptionsAgent {
+    symbols: Vec<String>,
+    expiries: Vec<String>,
+    rest_url: String,
+    poll_interval_secs: u64,
+}
+
+impl BinanceOptionsAgent {
+    pub fn new(symbols: Vec<String>, expiries: Vec<String>, cfg: &Settings) -> Self {
+        Self {
+            symbols,
+            expiries,
+            rest_url: cfg.binance_options_rest_url.clone(),
+            poll_interval_secs: cfg.binance_options_poll_interval_secs,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Agent for BinanceOptionsAgent {
+    fn name(&self) -> &'static str {
+        "binance_options"
+    }
+
+    async fn run(
+        &mut self,
+        mut shutdown: tokio::sync::watch::Receiver<bool>,
+        tx: mpsc::Sender<String>,
+    ) -> Result<(), IngestorError> {
+        let client = http_client::builder()
+            .build()
+            .map_err(|e| IngestorError::Http {
+                source: e,
+                exchange: "binance",
+                symbol: None,
+            })?;
+
+        loop {
+            for sym in &self.symbols {
+                for exp in &self.expiries {
+                    let url = format!("{}/optionChain?symbol={}&expiry={}", self.rest_url, sym, exp);
+                    match client.get(&url).send().await {
+                        Ok(resp) => match resp.json::<Value>().await {
+                            Ok(v) => {
+                                if let Some(event) = parse_chain(sym, exp, &v) {
+                                    if tx
+                                        .send(serde_json::to_string(&event).unwrap())
+                                        .await
+                                        .is_err()
+                                    {
+                                        return Ok(());
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                tracing::error!(error=%e, "failed to decode option chain");
+                            }
+                        },
+                        Err(e) => {
+                            tracing::error!(error=%e, "binance option chain request failed");
+                        }
+                    }
+                }
+            }
+
+            tokio::select! {
+                _ = tokio::time::sleep(Duration::from_secs(self.poll_interval_secs)) => {},
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() { break; }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn parse_chain(symbol: &str, expiry: &str, v: &Value) -> Option<OptionChain> {
+    let canon = CanonicalService::canonical_pair("binance", symbol)?;
+    let expiry_ts = parse_expiry(expiry)?;
+
+    let mut options = Vec::new();
+    if let Some(arr) = v.get("data").and_then(|d| d.as_array()).or_else(|| v.as_array()) {
+        for item in arr {
+            let strike = as_f64(item, "strike").or_else(|| as_f64(item, "strikePrice"))?;
+            if let Some(call) = item.get("call") {
+                if let Some(q) = parse_side(strike, "CALL", call) {
+                    options.push(q);
+                }
+            }
+            if let Some(put) = item.get("put") {
+                if let Some(q) = parse_side(strike, "PUT", put) {
+                    options.push(q);
+                }
+            }
+        }
+    }
+
+    Some(OptionChain {
+        agent: "binance".to_string(),
+        r#type: "option_chain".to_string(),
+        s: canon,
+        expiry: expiry_ts,
+        options,
+    })
+}
+
+fn parse_side(strike: f64, kind: &str, v: &Value) -> Option<OptionQuote> {
+    let bid = as_f64(v, "bid");
+    let ask = as_f64(v, "ask");
+    let last = as_f64(v, "lastPrice").or_else(|| as_f64(v, "last"));
+    let iv = as_f64(v, "iv").or_else(|| as_f64(v, "impliedVol"));
+    let greeks = {
+        let delta = as_f64(v, "delta");
+        let gamma = as_f64(v, "gamma");
+        let theta = as_f64(v, "theta");
+        let vega = as_f64(v, "vega");
+        if delta.is_some() || gamma.is_some() || theta.is_some() || vega.is_some() {
+            Some(OptionGreeks {
+                delta,
+                gamma,
+                theta,
+                vega,
+            })
+        } else {
+            None
+        }
+    };
+
+    Some(OptionQuote {
+        strike,
+        kind: kind.to_string(),
+        bid,
+        ask,
+        last,
+        iv,
+        greeks,
+    })
+}
+
+fn as_f64(v: &Value, key: &str) -> Option<f64> {
+    v.get(key)
+        .and_then(|x| x.as_f64().or_else(|| x.as_str().and_then(|s| s.parse().ok())))
+}
+
+fn parse_expiry(exp: &str) -> Option<i64> {
+    use chrono::{NaiveDate, TimeZone, Utc};
+    let d = NaiveDate::parse_from_str(exp, "%Y-%m-%d").ok()?;
+    let dt = d.and_hms_opt(0, 0, 0)?;
+    Some(Utc.from_utc_datetime(&dt).timestamp())
+}
+
+pub struct BinanceOptionsFactory;
+
+#[async_trait::async_trait]
+impl crate::agents::AgentFactory for BinanceOptionsFactory {
+    async fn create(&self, spec: &str, cfg: &Settings) -> Option<Box<dyn Agent>> {
+        let mut symbols: Vec<String> = if spec.trim().is_empty() {
+            cfg.binance_options_symbols.clone()
+        } else {
+            spec.split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        };
+        if symbols.is_empty() {
+            tracing::error!("no binance option symbols specified");
+            return None;
+        }
+        let expiries = if cfg.binance_options_expiries.is_empty() {
+            tracing::error!("no binance option expiries specified");
+            return None;
+        } else {
+            cfg.binance_options_expiries.clone()
+        };
+        let agent = BinanceOptionsAgent::new(symbols.drain(..).collect(), expiries, cfg);
+        Some(Box::new(agent))
+    }
+}
+

--- a/crypto-ingestor/src/agents/mod.rs
+++ b/crypto-ingestor/src/agents/mod.rs
@@ -16,6 +16,7 @@ pub static AGENT_FACTORIES: Lazy<Mutex<HashMap<&'static str, Box<dyn AgentFactor
     Lazy::new(|| {
         let mut m: HashMap<&'static str, Box<dyn AgentFactory>> = HashMap::new();
         m.insert("binance", Box::new(binance::BinanceFactory));
+        m.insert("binance_options", Box::new(binance::options::BinanceOptionsFactory));
         m.insert("coinbase", Box::new(coinbase::CoinbaseFactory));
         Mutex::new(m)
     });

--- a/crypto-ingestor/src/config.rs
+++ b/crypto-ingestor/src/config.rs
@@ -38,6 +38,14 @@ pub struct Settings {
     pub binance_ws_url: String,
     pub binance_refresh_interval_mins: u64,
     pub binance_max_reconnect_delay_secs: u64,
+    #[serde(default)]
+    pub binance_options_rest_url: String,
+    #[serde(default)]
+    pub binance_options_symbols: Vec<String>,
+    #[serde(default)]
+    pub binance_options_expiries: Vec<String>,
+    #[serde(default = "default_binance_options_poll_interval_secs")]
+    pub binance_options_poll_interval_secs: u64,
     pub coinbase_ws_url: String,
     pub coinbase_refresh_interval_mins: u64,
     pub coinbase_max_reconnect_delay_secs: u64,
@@ -55,12 +63,20 @@ fn default_sink() -> String {
     "stdout".into()
 }
 
+fn default_binance_options_poll_interval_secs() -> u64 {
+    60
+}
+
 impl Default for Settings {
     fn default() -> Self {
         Self {
             binance_ws_url: String::new(),
             binance_refresh_interval_mins: 60,
             binance_max_reconnect_delay_secs: 30,
+            binance_options_rest_url: String::new(),
+            binance_options_symbols: Vec::new(),
+            binance_options_expiries: Vec::new(),
+            binance_options_poll_interval_secs: 60,
             coinbase_ws_url: String::new(),
             coinbase_refresh_interval_mins: DEFAULT_COINBASE_REFRESH_INTERVAL_MINS,
             coinbase_max_reconnect_delay_secs: 30,
@@ -78,6 +94,8 @@ impl Settings {
             .set_default("binance_ws_url", "wss://stream.binance.us:9443/ws")?
             .set_default("binance_refresh_interval_mins", 60)?
             .set_default("binance_max_reconnect_delay_secs", 30)?
+            .set_default("binance_options_rest_url", "https://eapi.binance.com/eapi/v1")?
+            .set_default("binance_options_poll_interval_secs", 60)?
             .set_default("coinbase_ws_url", "wss://ws-feed.exchange.coinbase.com")?
             .set_default(
                 "coinbase_refresh_interval_mins",


### PR DESCRIPTION
## Summary
- add `OptionChain` event struct with greeks and IV surface
- add Binance options agent polling REST API with configurable symbols and expiries
- wire options agent into configuration and agent factory

## Testing
- `cargo test -p canonicalizer`
- `cargo test -p ingestor`


------
https://chatgpt.com/codex/tasks/task_e_68ad1ff43f788323bd4c51f8d774c181