### PR TITLE
Remove duplicate chrono dependency

### DIFF
--- a/analytics/Cargo.toml
+++ b/analytics/Cargo.toml
@@ -9,7 +9,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
-chrono = { version = "0.4", features = ["clock"] }
 canonicalizer = { path = "../canonicalizer" }
 ordered-float = "3"
 chrono = { version = "0.4", features = ["clock", "serde"] }


### PR DESCRIPTION
## Summary
- remove redundant chrono entry from `analytics` crate dependencies

## Testing
- `cargo +nightly check -p analytics` *(fails: the module `events` is defined multiple times in canonicalizer)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2c33ddc88323bcc36ed94d491b55