### PR TITLE
Fix duplicate events module declaration in canonicalizer

### DIFF
--- a/canonicalizer/src/lib.rs
+++ b/canonicalizer/src/lib.rs
@@ -19,7 +19,6 @@
 
 pub mod events;
 mod http_client;
-pub mod events;
 
 pub use events::{OptionChain, OptionGreeks, OptionQuote};
 pub mod onchain;


### PR DESCRIPTION
## Summary
- remove duplicate `events` module declaration in `canonicalizer` to resolve E0428 compile error

## Testing
- `cargo test -p canonicalizer`

------
https://chatgpt.com/codex/tasks/task_e_68ae5e4fbd948323bd1aa02890e36330