### PR TITLE
Remove unused token state field

### DIFF
--- a/crypto-ingestor/src/agents/onchain.rs
+++ b/crypto-ingestor/src/agents/onchain.rs
@@ -7,13 +7,12 @@ use tokio::sync::{mpsc::Sender, watch};
 
 use std::sync::Arc;
 
-use crate::{agent::Agent, config::Settings, error::IngestorError, labels::load_labels, token_state::TokenState};
+use crate::{agent::Agent, config::Settings, error::IngestorError, labels::load_labels};
 
 pub struct OnchainAgent {
     provider: Arc<Provider<Ws>>,
     pending: HashMap<H256, Transaction>,
     labels: HashMap<Address, String>,
-    token_state: TokenState,
 }
 
 impl OnchainAgent {
@@ -30,7 +29,6 @@ impl OnchainAgent {
             provider,
             pending: HashMap::new(),
             labels,
-            token_state: TokenState::new(),
         })
     }
 }


### PR DESCRIPTION
## Summary
- remove unused token state field and import from onchain agent

## Testing
- `cargo check -p ingestor`
- `cargo test -p ingestor` *(fails: binance_trade_messages_are_canonicalized_with_id; coinbase_trade_messages_are_canonicalized_with_id running over 60s)*

------
https://chatgpt.com/codex/tasks/task_e_68ae79efca788323b1a8ab5a2b0858a4