### PR TITLE
Add REST OHLCV polling agents for Binance and Coinbase

### DIFF
--- a/canonicalizer/src/events.rs
+++ b/canonicalizer/src/events.rs
@@ -60,6 +60,40 @@ pub struct Liquidation {
     #[serde(rename = "ts")]
     pub timestamp: i64,
 }
+
+/// Candlestick bar (open-high-low-close-volume) for a trading pair.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Bar {
+    /// Source exchange name.
+    pub agent: String,
+    /// Event type, always `"ohlcv"`.
+    #[serde(rename = "type")]
+    pub r#type: String,
+    /// Canonical `BASE-QUOTE` symbol.
+    #[serde(rename = "s")]
+    pub symbol: String,
+    /// Bar interval in seconds.
+    #[serde(rename = "i")]
+    pub interval: u64,
+    /// Open price.
+    #[serde(rename = "o")]
+    pub open: String,
+    /// High price.
+    #[serde(rename = "h")]
+    pub high: String,
+    /// Low price.
+    #[serde(rename = "l")]
+    pub low: String,
+    /// Close price.
+    #[serde(rename = "c")]
+    pub close: String,
+    /// Traded volume during the interval.
+    #[serde(rename = "v")]
+    pub volume: String,
+    /// Start timestamp of the bar in milliseconds.
+    #[serde(rename = "ts")]
+    pub timestamp: i64,
+}
 /// Greeks associated with an option contract.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct OptionGreeks {
@@ -140,4 +174,3 @@ mod tests {
         assert_eq!(back, chain);
     }
 }
-

--- a/canonicalizer/src/lib.rs
+++ b/canonicalizer/src/lib.rs
@@ -20,14 +20,14 @@
 pub mod events;
 mod http_client;
 
-pub use events::{OptionChain, OptionGreeks, OptionQuote};
+pub use events::{Bar, OptionChain, OptionGreeks, OptionQuote};
 pub mod onchain;
 
 use std::collections::HashSet;
 use std::sync::OnceLock;
 
+use serde::{Deserialize, Serialize};
 use tracing::warn;
-use serde::{Serialize, Deserialize};
 
 pub struct CanonicalService;
 
@@ -176,8 +176,15 @@ pub struct L2Diff {
 }
 
 impl L2Diff {
-    pub fn new(agent: &str, symbol: &str, bids: Vec<[String; 2]>, asks: Vec<[String; 2]>, ts: i64) -> Self {
-        let sym = CanonicalService::canonical_pair(agent, symbol).unwrap_or_else(|| symbol.to_string());
+    pub fn new(
+        agent: &str,
+        symbol: &str,
+        bids: Vec<[String; 2]>,
+        asks: Vec<[String; 2]>,
+        ts: i64,
+    ) -> Self {
+        let sym =
+            CanonicalService::canonical_pair(agent, symbol).unwrap_or_else(|| symbol.to_string());
         Self {
             agent: agent.to_string(),
             event_type: "l2_diff".to_string(),
@@ -208,8 +215,15 @@ pub struct Snapshot {
 }
 
 impl Snapshot {
-    pub fn new(agent: &str, symbol: &str, bids: Vec<[String; 2]>, asks: Vec<[String; 2]>, ts: i64) -> Self {
-        let sym = CanonicalService::canonical_pair(agent, symbol).unwrap_or_else(|| symbol.to_string());
+    pub fn new(
+        agent: &str,
+        symbol: &str,
+        bids: Vec<[String; 2]>,
+        asks: Vec<[String; 2]>,
+        ts: i64,
+    ) -> Self {
+        let sym =
+            CanonicalService::canonical_pair(agent, symbol).unwrap_or_else(|| symbol.to_string());
         Self {
             agent: agent.to_string(),
             event_type: "snapshot".to_string(),

--- a/crypto-ingestor/src/agents/binance/ohlcv.rs
+++ b/crypto-ingestor/src/agents/binance/ohlcv.rs
@@ -1,0 +1,173 @@
+use std::time::Duration;
+
+use canonicalizer::{Bar, CanonicalService};
+use futures_util::future::join_all;
+use tokio::sync::mpsc;
+
+use crate::{agent::Agent, config::Settings, error::IngestorError, http_client};
+
+pub struct BinanceOhlcvAgent {
+    symbols: Vec<String>,
+    intervals: Vec<u64>,
+    poll_interval_secs: u64,
+}
+
+impl BinanceOhlcvAgent {
+    pub fn new(symbols: Vec<String>, intervals: Vec<u64>, cfg: &Settings) -> Self {
+        Self {
+            symbols,
+            intervals,
+            poll_interval_secs: cfg.binance_ohlcv_poll_interval_secs,
+        }
+    }
+}
+
+fn interval_str(secs: u64) -> String {
+    const MINUTE: u64 = 60;
+    const HOUR: u64 = 60 * MINUTE;
+    const DAY: u64 = 24 * HOUR;
+    const WEEK: u64 = 7 * DAY;
+    if secs % WEEK == 0 {
+        format!("{}w", secs / WEEK)
+    } else if secs % DAY == 0 {
+        format!("{}d", secs / DAY)
+    } else if secs % HOUR == 0 {
+        format!("{}h", secs / HOUR)
+    } else if secs % MINUTE == 0 {
+        format!("{}m", secs / MINUTE)
+    } else {
+        format!("{}s", secs)
+    }
+}
+
+pub async fn fetch_bar(client: &reqwest::Client, symbol: &str, interval: u64) -> Option<Bar> {
+    let url = format!(
+        "https://api.binance.us/api/v3/klines?symbol={}&interval={}&limit=1",
+        symbol.to_uppercase(),
+        interval_str(interval)
+    );
+    let mut delay = Duration::from_millis(500);
+    for _ in 0..3 {
+        match client.get(&url).send().await {
+            Ok(resp) => {
+                let status = resp.status();
+                if status.is_success() {
+                    if let Ok(v) = resp.json::<serde_json::Value>().await {
+                        if let Some(bar) = parse_bar(symbol, interval, &v) {
+                            return Some(bar);
+                        }
+                    }
+                    break;
+                } else if status.as_u16() == 429 || status.is_server_error() {
+                    tokio::time::sleep(delay).await;
+                    delay *= 2;
+                } else {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    None
+}
+
+pub fn parse_bar(symbol: &str, interval: u64, v: &serde_json::Value) -> Option<Bar> {
+    let first = v.as_array()?.get(0)?.as_array()?;
+    let ts = first.get(0)?.as_i64()?;
+    let open = first.get(1)?.as_str()?.to_string();
+    let high = first.get(2)?.as_str()?.to_string();
+    let low = first.get(3)?.as_str()?.to_string();
+    let close = first.get(4)?.as_str()?.to_string();
+    let volume = first.get(5)?.as_str()?.to_string();
+    let sym =
+        CanonicalService::canonical_pair("binance", symbol).unwrap_or_else(|| symbol.to_string());
+    Some(Bar {
+        agent: "binance".into(),
+        r#type: "ohlcv".into(),
+        symbol: sym,
+        interval,
+        open,
+        high,
+        low,
+        close,
+        volume,
+        timestamp: ts,
+    })
+}
+
+#[async_trait::async_trait]
+impl Agent for BinanceOhlcvAgent {
+    fn name(&self) -> &'static str {
+        "binance_ohlcv"
+    }
+
+    fn event_types(&self) -> Vec<crate::agent::EventType> {
+        Vec::new()
+    }
+
+    async fn run(
+        &mut self,
+        mut shutdown: tokio::sync::watch::Receiver<bool>,
+        tx: mpsc::Sender<String>,
+    ) -> Result<(), IngestorError> {
+        let client = http_client::builder()
+            .build()
+            .map_err(|e| IngestorError::Http {
+                source: e,
+                exchange: "binance",
+                symbol: None,
+            })?;
+
+        loop {
+            let mut futs = Vec::new();
+            for s in &self.symbols {
+                for &i in &self.intervals {
+                    let client = client.clone();
+                    let symbol = s.clone();
+                    let tx = tx.clone();
+                    futs.push(async move {
+                        if let Some(bar) = fetch_bar(&client, &symbol, i).await {
+                            let _ = tx.send(serde_json::to_string(&bar).unwrap()).await;
+                        }
+                    });
+                }
+            }
+            join_all(futs).await;
+            tokio::select! {
+                _ = tokio::time::sleep(Duration::from_secs(self.poll_interval_secs)) => {},
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() { break; }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct BinanceOhlcvFactory;
+
+#[async_trait::async_trait]
+impl super::super::AgentFactory for BinanceOhlcvFactory {
+    async fn create(&self, spec: &str, cfg: &Settings) -> Option<Box<dyn Agent>> {
+        let symbols = if spec.trim().is_empty() || spec.eq_ignore_ascii_case("all") {
+            match super::fetch_all_symbols().await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::error!(error=%e, "failed to fetch binance symbols");
+                    return None;
+                }
+            }
+        } else {
+            spec.split(',')
+                .map(|s| s.trim().to_lowercase())
+                .filter(|s| !s.is_empty())
+                .collect()
+        };
+        if cfg.binance_ohlcv_intervals.is_empty() {
+            tracing::error!("no binance ohlcv intervals specified");
+            return None;
+        }
+        let agent = BinanceOhlcvAgent::new(symbols, cfg.binance_ohlcv_intervals.clone(), cfg);
+        Some(Box::new(agent))
+    }
+}

--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -1,4 +1,5 @@
 use futures_util::{SinkExt, StreamExt};
+pub mod ohlcv;
 use std::collections::{HashMap, HashSet};
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};

--- a/crypto-ingestor/src/agents/coinbase/ohlcv.rs
+++ b/crypto-ingestor/src/agents/coinbase/ohlcv.rs
@@ -1,0 +1,159 @@
+use std::time::Duration;
+
+use canonicalizer::{Bar, CanonicalService};
+use futures_util::future::join_all;
+use tokio::sync::mpsc;
+
+use crate::{agent::Agent, config::Settings, error::IngestorError, http_client};
+
+pub struct CoinbaseOhlcvAgent {
+    symbols: Vec<String>,
+    intervals: Vec<u64>,
+    poll_interval_secs: u64,
+}
+
+impl CoinbaseOhlcvAgent {
+    pub fn new(symbols: Vec<String>, intervals: Vec<u64>, cfg: &Settings) -> Self {
+        Self {
+            symbols,
+            intervals,
+            poll_interval_secs: cfg.coinbase_ohlcv_poll_interval_secs,
+        }
+    }
+}
+
+fn val_to_string(v: &serde_json::Value) -> String {
+    v.as_str()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| v.to_string())
+}
+
+pub async fn fetch_bar(client: &reqwest::Client, symbol: &str, interval: u64) -> Option<Bar> {
+    let url = format!(
+        "https://api.exchange.coinbase.com/products/{}/candles?granularity={}&limit=1",
+        symbol, interval
+    );
+    let mut delay = Duration::from_millis(500);
+    for _ in 0..3 {
+        match client.get(&url).send().await {
+            Ok(resp) => {
+                let status = resp.status();
+                if status.is_success() {
+                    if let Ok(v) = resp.json::<serde_json::Value>().await {
+                        if let Some(bar) = parse_bar(symbol, interval, &v) {
+                            return Some(bar);
+                        }
+                    }
+                    break;
+                } else if status.as_u16() == 429 || status.is_server_error() {
+                    tokio::time::sleep(delay).await;
+                    delay *= 2;
+                } else {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    None
+}
+
+pub fn parse_bar(symbol: &str, interval: u64, v: &serde_json::Value) -> Option<Bar> {
+    let first = v.as_array()?.get(0)?.as_array()?;
+    let ts = first.get(0)?.as_i64()? * 1000; // seconds to ms
+    let low = val_to_string(first.get(1)?);
+    let high = val_to_string(first.get(2)?);
+    let open = val_to_string(first.get(3)?);
+    let close = val_to_string(first.get(4)?);
+    let volume = val_to_string(first.get(5)?);
+    let sym =
+        CanonicalService::canonical_pair("coinbase", symbol).unwrap_or_else(|| symbol.to_string());
+    Some(Bar {
+        agent: "coinbase".into(),
+        r#type: "ohlcv".into(),
+        symbol: sym,
+        interval,
+        open,
+        high,
+        low,
+        close,
+        volume,
+        timestamp: ts,
+    })
+}
+
+#[async_trait::async_trait]
+impl Agent for CoinbaseOhlcvAgent {
+    fn name(&self) -> &'static str {
+        "coinbase_ohlcv"
+    }
+
+    fn event_types(&self) -> Vec<crate::agent::EventType> {
+        Vec::new()
+    }
+
+    async fn run(
+        &mut self,
+        mut shutdown: tokio::sync::watch::Receiver<bool>,
+        tx: mpsc::Sender<String>,
+    ) -> Result<(), IngestorError> {
+        let client = http_client::builder()
+            .build()
+            .map_err(|e| IngestorError::Http {
+                source: e,
+                exchange: "coinbase",
+                symbol: None,
+            })?;
+        loop {
+            let mut futs = Vec::new();
+            for s in &self.symbols {
+                for &i in &self.intervals {
+                    let client = client.clone();
+                    let symbol = s.clone();
+                    let tx = tx.clone();
+                    futs.push(async move {
+                        if let Some(bar) = fetch_bar(&client, &symbol, i).await {
+                            let _ = tx.send(serde_json::to_string(&bar).unwrap()).await;
+                        }
+                    });
+                }
+            }
+            join_all(futs).await;
+            tokio::select! {
+                _ = tokio::time::sleep(Duration::from_secs(self.poll_interval_secs)) => {},
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() { break; }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct CoinbaseOhlcvFactory;
+
+#[async_trait::async_trait]
+impl super::super::AgentFactory for CoinbaseOhlcvFactory {
+    async fn create(&self, spec: &str, cfg: &Settings) -> Option<Box<dyn Agent>> {
+        let symbols = if spec.trim().is_empty() || spec.eq_ignore_ascii_case("all") {
+            match super::fetch_all_symbols().await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::error!(error=%e, "failed to fetch coinbase symbols");
+                    return None;
+                }
+            }
+        } else {
+            spec.split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        };
+        if cfg.coinbase_ohlcv_intervals.is_empty() {
+            tracing::error!("no coinbase ohlcv intervals specified");
+            return None;
+        }
+        let agent = CoinbaseOhlcvAgent::new(symbols, cfg.coinbase_ohlcv_intervals.clone(), cfg);
+        Some(Box::new(agent))
+    }
+}

--- a/crypto-ingestor/src/agents/mod.rs
+++ b/crypto-ingestor/src/agents/mod.rs
@@ -17,8 +17,19 @@ pub static AGENT_FACTORIES: Lazy<Mutex<HashMap<&'static str, Box<dyn AgentFactor
     Lazy::new(|| {
         let mut m: HashMap<&'static str, Box<dyn AgentFactory>> = HashMap::new();
         m.insert("binance", Box::new(binance::BinanceFactory));
-        m.insert("binance_options", Box::new(binance::options::BinanceOptionsFactory));
+        m.insert(
+            "binance_options",
+            Box::new(binance::options::BinanceOptionsFactory),
+        );
+        m.insert(
+            "binance_ohlcv",
+            Box::new(binance::ohlcv::BinanceOhlcvFactory),
+        );
         m.insert("coinbase", Box::new(coinbase::CoinbaseFactory));
+        m.insert(
+            "coinbase_ohlcv",
+            Box::new(coinbase::ohlcv::CoinbaseOhlcvFactory),
+        );
         m.insert("onchain", Box::new(onchain::OnchainFactory));
         Mutex::new(m)
     });

--- a/crypto-ingestor/src/config.rs
+++ b/crypto-ingestor/src/config.rs
@@ -106,9 +106,17 @@ pub struct Settings {
     pub binance_options_expiries: Vec<String>,
     #[serde(default = "default_binance_options_poll_interval_secs")]
     pub binance_options_poll_interval_secs: u64,
+    #[serde(default)]
+    pub binance_ohlcv_intervals: Vec<u64>,
+    #[serde(default = "default_binance_ohlcv_poll_interval_secs")]
+    pub binance_ohlcv_poll_interval_secs: u64,
     pub coinbase_ws_url: String,
     pub coinbase_refresh_interval_mins: u64,
     pub coinbase_max_reconnect_delay_secs: u64,
+    #[serde(default)]
+    pub coinbase_ohlcv_intervals: Vec<u64>,
+    #[serde(default = "default_coinbase_ohlcv_poll_interval_secs")]
+    pub coinbase_ohlcv_poll_interval_secs: u64,
     #[serde(default = "default_sink")]
     pub sink: String,
     #[serde(default)]
@@ -158,6 +166,14 @@ fn default_binance_options_poll_interval_secs() -> u64 {
     60
 }
 
+fn default_binance_ohlcv_poll_interval_secs() -> u64 {
+    60
+}
+
+fn default_coinbase_ohlcv_poll_interval_secs() -> u64 {
+    60
+}
+
 impl Default for Settings {
     fn default() -> Self {
         Self {
@@ -168,9 +184,13 @@ impl Default for Settings {
             binance_options_symbols: Vec::new(),
             binance_options_expiries: Vec::new(),
             binance_options_poll_interval_secs: 60,
+            binance_ohlcv_intervals: Vec::new(),
+            binance_ohlcv_poll_interval_secs: 60,
             coinbase_ws_url: String::new(),
             coinbase_refresh_interval_mins: DEFAULT_COINBASE_REFRESH_INTERVAL_MINS,
             coinbase_max_reconnect_delay_secs: 30,
+            coinbase_ohlcv_intervals: Vec::new(),
+            coinbase_ohlcv_poll_interval_secs: 60,
             sink: default_sink(),
             kafka_brokers: None,
             kafka_topic: None,
@@ -200,14 +220,21 @@ impl Settings {
             .set_default("binance_ws_url", "wss://stream.binance.us:9443/ws")?
             .set_default("binance_refresh_interval_mins", 60)?
             .set_default("binance_max_reconnect_delay_secs", 30)?
-            .set_default("binance_options_rest_url", "https://eapi.binance.com/eapi/v1")?
+            .set_default(
+                "binance_options_rest_url",
+                "https://eapi.binance.com/eapi/v1",
+            )?
             .set_default("binance_options_poll_interval_secs", 60)?
+            .set_default("binance_ohlcv_poll_interval_secs", 60)?
+            .set_default("binance_ohlcv_intervals", vec![60])?
             .set_default("coinbase_ws_url", "wss://ws-feed.exchange.coinbase.com")?
             .set_default(
                 "coinbase_refresh_interval_mins",
                 DEFAULT_COINBASE_REFRESH_INTERVAL_MINS,
             )?
             .set_default("coinbase_max_reconnect_delay_secs", 30)?
+            .set_default("coinbase_ohlcv_poll_interval_secs", 60)?
+            .set_default("coinbase_ohlcv_intervals", vec![60])?
             .set_default("sink", "stdout")?
             .set_default("trades", false)?
             .set_default("l2_diffs", false)?

--- a/crypto-ingestor/tests/ohlcv.rs
+++ b/crypto-ingestor/tests/ohlcv.rs
@@ -1,0 +1,31 @@
+use canonicalizer::CanonicalService;
+use ingestor::agents::binance::ohlcv::parse_bar as parse_binance_bar;
+use ingestor::agents::coinbase::ohlcv::parse_bar as parse_coinbase_bar;
+use serde_json::json;
+use std::sync::Once;
+
+async fn setup() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        std::env::set_var("BINANCE_QUOTES", "usdt,usdc,busd,usd,btc,eth,bnb");
+    });
+    CanonicalService::init().await;
+}
+
+#[tokio::test]
+async fn binance_bar_canonicalized() {
+    setup().await;
+    let data = json!([[0, "1.0", "2.0", "0.5", "1.5", "100", 0, "0", 0, "0", "0", "0"]]);
+    let bar = parse_binance_bar("btcusdt", 60, &data).expect("parse");
+    assert_eq!(bar.symbol, "BTC-USDT");
+    assert_eq!(bar.open, "1.0");
+}
+
+#[tokio::test]
+async fn coinbase_bar_canonicalized() {
+    setup().await;
+    let data = json!([[0, 0.5, 2.0, 1.0, 1.5, 100.0]]);
+    let bar = parse_coinbase_bar("BTC-USD", 60, &data).expect("parse");
+    assert_eq!(bar.symbol, "BTC-USD");
+    assert_eq!(bar.close, "1.5");
+}


### PR DESCRIPTION
## Summary
- add canonical `Bar` event and export from canonicalizer
- implement Binance & Coinbase OHLCV REST agents with batching and retries
- expose OHLCV polling configuration and register new agents
- add integration tests for bar canonicalization

## Testing
- `cargo test --test ohlcv`
- `cargo test` *(fails: binance_trade_messages_are_canonicalized_with_id, coinbase_trade_messages_are_canonicalized_with_id)*

------
https://chatgpt.com/codex/tasks/task_e_68afab67d3e48323858f4d20b5182ab8