### PR TITLE
Clean up unused code in account agents

### DIFF
--- a/crypto-ingestor/src/agents/binance/account.rs
+++ b/crypto-ingestor/src/agents/binance/account.rs
@@ -16,7 +16,6 @@ use canonicalizer::{CanonicalService, Fill, Order, Position};
 /// Binance account stream handler.
 pub struct BinanceAccount {
     api_key: String,
-    api_secret: String,
     ws_url: String,
     offset_file: PathBuf,
 }
@@ -25,11 +24,10 @@ impl BinanceAccount {
     /// Create a new account agent if API credentials are configured.
     pub fn new(cfg: &Settings) -> Option<Self> {
         let api_key = cfg.binance_api_key.clone()?;
-        let api_secret = cfg.binance_api_secret.clone()?;
+        let _api_secret = cfg.binance_api_secret.clone()?;
         let ws_url = cfg.binance_ws_url.clone();
         Some(Self {
             api_key,
-            api_secret,
             ws_url,
             offset_file: PathBuf::from("binance_account.offset"),
         })
@@ -86,7 +84,7 @@ impl Agent for BinanceAccount {
 
     async fn run(
         &mut self,
-        mut shutdown: watch::Receiver<bool>,
+        shutdown: watch::Receiver<bool>,
         out_tx: mpsc::Sender<String>,
     ) -> Result<(), IngestorError> {
         let mut backoff = 1u64;

--- a/crypto-ingestor/src/agents/coinbase/account.rs
+++ b/crypto-ingestor/src/agents/coinbase/account.rs
@@ -1,12 +1,8 @@
-use std::path::PathBuf;
-
 use futures_util::{SinkExt, StreamExt};
 use tokio::sync::{mpsc, watch};
 use tokio_tungstenite::connect_async;
 
 use crate::{agent::Agent, config::Settings, error::IngestorError, http_client};
-
-use canonicalizer::{Fill, Order, Position};
 
 /// Coinbase account stream handler. This is a minimal implementation that
 /// authenticates and listens for user-channel messages.
@@ -14,7 +10,6 @@ pub struct CoinbaseAccount {
     api_key: String,
     api_secret: String,
     ws_url: String,
-    offset_file: PathBuf,
 }
 
 impl CoinbaseAccount {
@@ -26,7 +21,6 @@ impl CoinbaseAccount {
             api_key,
             api_secret,
             ws_url,
-            offset_file: PathBuf::from("coinbase_account.offset"),
         })
     }
 
@@ -43,7 +37,7 @@ impl Agent for CoinbaseAccount {
 
     async fn run(
         &mut self,
-        mut shutdown: watch::Receiver<bool>,
+        shutdown: watch::Receiver<bool>,
         _out_tx: mpsc::Sender<String>,
     ) -> Result<(), IngestorError> {
         let (ws, _) = connect_async(&self.ws_url)


### PR DESCRIPTION
## Summary
- remove unused canonicalizer imports and offset file from Coinbase account agent
- drop unused API secret field from Binance account agent
- avoid mutability on account shutdown channels

## Testing
- `cargo test` *(fails: terminated)*
- `cargo check -p ingestor`

------
https://chatgpt.com/codex/tasks/task_e_68afbb9d67288323b6e1d0675db59a31