### PR TITLE
Switch Binance endpoints to Binance US

### DIFF
--- a/crypto-ingestor/src/agents/binance/funding_history.rs
+++ b/crypto-ingestor/src/agents/binance/funding_history.rs
@@ -47,7 +47,7 @@ async fn backfill_symbol(
     let mut start: i64 = 0;
     loop {
         let url = format!(
-            "https://fapi.binance.com/fapi/v1/fundingRate?symbol={}&limit={}&startTime={}",
+            "https://fapi.binance.us/fapi/v1/fundingRate?symbol={}&limit={}&startTime={}",
             symbol.to_uppercase(),
             LIMIT,
             start
@@ -119,4 +119,3 @@ async fn backfill_symbol(
     }
     Ok(())
 }
-

--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -690,7 +690,7 @@ async fn send_unsubscribe(
 }
 
 async fn mark_price_task(shutdown: tokio::sync::watch::Receiver<bool>, tx: mpsc::Sender<String>) {
-    let url = "wss://fstream.binance.com/stream?streams=!markPrice@arr";
+    let url = "wss://fstream.binance.us/stream?streams=!markPrice@arr";
     aggregated_ws_loop(url, "mark_price", shutdown, tx, |item| {
         let raw = item.get("s").and_then(|s| s.as_str()).unwrap_or("?");
         let sym =
@@ -715,7 +715,7 @@ async fn mark_price_task(shutdown: tokio::sync::watch::Receiver<bool>, tx: mpsc:
 }
 
 async fn funding_rate_task(shutdown: tokio::sync::watch::Receiver<bool>, tx: mpsc::Sender<String>) {
-    let url = "wss://fstream.binance.com/stream?streams=!fundingRate@arr";
+    let url = "wss://fstream.binance.us/stream?streams=!fundingRate@arr";
     aggregated_ws_loop(url, "funding", shutdown, tx, |item| {
         let raw = item.get("s").and_then(|s| s.as_str()).unwrap_or("?");
         let sym =
@@ -743,7 +743,7 @@ async fn open_interest_task(
     shutdown: tokio::sync::watch::Receiver<bool>,
     tx: mpsc::Sender<String>,
 ) {
-    let url = "wss://fstream.binance.com/stream?streams=!openInterest@arr";
+    let url = "wss://fstream.binance.us/stream?streams=!openInterest@arr";
     aggregated_ws_loop(url, "open_interest", shutdown, tx, |item| {
         let raw = item.get("s").and_then(|s| s.as_str()).unwrap_or("?");
         let sym =
@@ -768,7 +768,7 @@ async fn open_interest_task(
 }
 
 async fn liquidation_task(shutdown: tokio::sync::watch::Receiver<bool>, tx: mpsc::Sender<String>) {
-    let url = "wss://fstream.binance.com/stream?streams=!forceOrder@arr";
+    let url = "wss://fstream.binance.us/stream?streams=!forceOrder@arr";
     aggregated_ws_loop(url, "liquidation", shutdown, tx, |item| {
         let raw = item.get("s").and_then(|s| s.as_str()).unwrap_or("?");
         let sym =
@@ -822,7 +822,7 @@ async fn term_structure_task(
             }
             _ = interval.tick() => {
                 for sym in &symbols {
-                    let url = format!("https://fapi.binance.com/futures/data/basis?symbol={}&period=5m&limit=1", sym.to_uppercase());
+                    let url = format!("https://fapi.binance.us/futures/data/basis?symbol={}&period=5m&limit=1", sym.to_uppercase());
                     if let Ok(resp) = client.get(&url).send().await {
                         if let Ok(resp) = resp.json::<serde_json::Value>().await {
                             if let Some(arr) = resp.as_array().and_then(|a| a.first()) {

--- a/crypto-ingestor/src/agents/binance/open_interest_history.rs
+++ b/crypto-ingestor/src/agents/binance/open_interest_history.rs
@@ -47,7 +47,7 @@ async fn backfill_symbol(
     let mut start: i64 = 0;
     loop {
         let url = format!(
-            "https://fapi.binance.com/fapi/v1/openInterestHist?symbol={}&period={}&limit={}&startTime={}",
+            "https://fapi.binance.us/fapi/v1/openInterestHist?symbol={}&period={}&limit={}&startTime={}",
             symbol.to_uppercase(),
             PERIOD,
             LIMIT,

--- a/crypto-ingestor/src/config.rs
+++ b/crypto-ingestor/src/config.rs
@@ -247,7 +247,7 @@ impl Settings {
             .set_default("binance_max_reconnect_delay_secs", 30)?
             .set_default(
                 "binance_options_rest_url",
-                "https://eapi.binance.com/eapi/v1",
+                "https://eapi.binance.us/eapi/v1",
             )?
             .set_default("binance_options_poll_interval_secs", 60)?
             .set_default("binance_ohlcv_poll_interval_secs", 60)?


### PR DESCRIPTION
## Summary
- Fix Binance open interest and funding history fetches by using Binance US API endpoints
- Point Binance futures websocket listeners and term structure fetches to Binance US
- Default Binance options REST URL to Binance US

## Testing
- `cargo test -p ingestor` *(tests ran but websocket tests hung; manual stop)*

------
https://chatgpt.com/codex/tasks/task_e_68afbfbf515483238ab38fa6e6e30e86