### PR TITLE
Remove crate-level release profile to avoid Cargo warning

### DIFF
--- a/crypto-ingestor/Cargo.toml
+++ b/crypto-ingestor/Cargo.toml
@@ -39,5 +39,3 @@ ethers = { version = "2", features = ["ws", "abigen"] }
 [dev-dependencies]
 tempfile = "3"
 
-[profile.release]
-opt-level = 3


### PR DESCRIPTION
## Summary
- remove release profile from `crypto-ingestor` crate so cargo uses the workspace profile

## Testing
- `cargo check -p ingestor` *(fails: build process exceeded time/compute limits for rdkafka-sys)*

------
https://chatgpt.com/codex/tasks/task_e_68afbf755154832389db0dcdcdb3bba7