### PR TITLE
Share reqwest client and support shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,6 +2433,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio 1.47.1",
+ "tokio-util 0.7.16",
  "tracing",
  "tracing-subscriber",
 ]

--- a/macro-data/Cargo.toml
+++ b/macro-data/Cargo.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "signal"] }
 reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["clock"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
+tokio-util = { version = "0.7" }
 
 [lib]
 path = "src/lib.rs"

--- a/macro-data/src/lib.rs
+++ b/macro-data/src/lib.rs
@@ -4,6 +4,7 @@ use chrono::{NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 use tokio::time::{interval, Duration};
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 /// Generic macroeconomic metric emitted by the service.
@@ -26,45 +27,91 @@ pub struct CryptoIndex {
 /// Spawn background tasks fetching macro data and crypto indices.
 ///
 /// Returns [`broadcast::Receiver`]s yielding [`MacroMetric`] and [`CryptoIndex`] events.
-pub fn spawn() -> (broadcast::Receiver<MacroMetric>, broadcast::Receiver<CryptoIndex>) {
+pub fn spawn(
+    shutdown: CancellationToken,
+) -> (
+    broadcast::Receiver<MacroMetric>,
+    broadcast::Receiver<CryptoIndex>,
+) {
     let (macro_tx, macro_rx) = broadcast::channel(100);
     let (crypto_tx, crypto_rx) = broadcast::channel(100);
 
-    tokio::spawn(run_fx_fetcher(macro_tx.clone()));
-    tokio::spawn(run_rates_fetcher(macro_tx.clone()));
-    tokio::spawn(run_commodity_fetcher(macro_tx.clone()));
-    tokio::spawn(run_equity_fetcher(macro_tx.clone()));
-    tokio::spawn(run_event_fetcher(macro_tx.clone()));
-    tokio::spawn(run_crypto_indices_fetcher(crypto_tx.clone()));
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("client");
+
+    tokio::spawn(run_fx_fetcher(
+        client.clone(),
+        macro_tx.clone(),
+        shutdown.clone(),
+    ));
+    tokio::spawn(run_rates_fetcher(
+        client.clone(),
+        macro_tx.clone(),
+        shutdown.clone(),
+    ));
+    tokio::spawn(run_commodity_fetcher(
+        client.clone(),
+        macro_tx.clone(),
+        shutdown.clone(),
+    ));
+    tokio::spawn(run_equity_fetcher(
+        client.clone(),
+        macro_tx.clone(),
+        shutdown.clone(),
+    ));
+    tokio::spawn(run_event_fetcher(
+        client.clone(),
+        macro_tx.clone(),
+        shutdown.clone(),
+    ));
+    tokio::spawn(run_crypto_indices_fetcher(
+        client,
+        crypto_tx.clone(),
+        shutdown,
+    ));
 
     (macro_rx, crypto_rx)
 }
 
-async fn run_fx_fetcher(tx: broadcast::Sender<MacroMetric>) {
-    let client = reqwest::Client::new();
+async fn run_fx_fetcher(
+    client: reqwest::Client,
+    tx: broadcast::Sender<MacroMetric>,
+    shutdown: CancellationToken,
+) {
     let mut intv = interval(Duration::from_secs(3600));
     loop {
-        intv.tick().await;
-        match client
-            .get("https://api.exchangerate.host/latest?base=USD&symbols=EUR,JPY,GBP")
-            .send()
-            .await
-        {
-            Ok(resp) => match resp.text().await {
-                Ok(body) => match parse_exchangerate_host(&body) {
-                    Ok(metrics) => metrics.into_iter().for_each(|m| {
-                        let _ = tx.send(m);
-                    }),
-                    Err(e) => info!("fx parse error: {}", e),
-                },
-                Err(e) => info!("fx body error: {}", e),
-            },
-            Err(e) => info!("fx fetch error: {}", e),
+        tokio::select! {
+            _ = intv.tick() => {
+                match client
+                    .get("https://api.exchangerate.host/latest?base=USD&symbols=EUR,JPY,GBP")
+                    .timeout(Duration::from_secs(10))
+                    .send()
+                    .await
+                {
+                    Ok(resp) => match resp.text().await {
+                        Ok(body) => match parse_exchangerate_host(&body) {
+                            Ok(metrics) => metrics.into_iter().for_each(|m| {
+                                let _ = tx.send(m);
+                            }),
+                            Err(e) => info!("fx parse error: {}", e),
+                        },
+                        Err(e) => info!("fx body error: {}", e),
+                    },
+                    Err(e) => info!("fx fetch error: {}", e),
+                }
+            }
+            _ = shutdown.cancelled() => break,
         }
     }
 }
 
-async fn run_rates_fetcher(tx: broadcast::Sender<MacroMetric>) {
+async fn run_rates_fetcher(
+    client: reqwest::Client,
+    tx: broadcast::Sender<MacroMetric>,
+    shutdown: CancellationToken,
+) {
     let api_key = match std::env::var("FRED_API_KEY") {
         Ok(k) => k,
         Err(_) => {
@@ -72,131 +119,166 @@ async fn run_rates_fetcher(tx: broadcast::Sender<MacroMetric>) {
             return;
         }
     };
-    let client = reqwest::Client::new();
     let mut intv = interval(Duration::from_secs(3600));
     loop {
-        intv.tick().await;
-        let url = format!("https://api.stlouisfed.org/fred/series/observations?series_id=DGS10&sort_order=desc&limit=1&api_key={}&file_type=json", api_key);
-        match client.get(&url).send().await {
-            Ok(resp) => match resp.text().await {
-                Ok(body) => match parse_fred_rate(&body) {
-                    Ok(Some(val)) => {
-                        let metric = MacroMetric {
-                            category: "rate".into(),
-                            symbol: "US10Y".into(),
-                            value: val,
-                            timestamp: Utc::now().timestamp_millis(),
-                        };
-                        let _ = tx.send(metric);
-                    }
-                    Ok(None) => info!("no rate data"),
-                    Err(e) => info!("rate parse error: {}", e),
-                },
-                Err(e) => info!("rate body error: {}", e),
-            },
-            Err(e) => info!("rate fetch error: {}", e),
+        tokio::select! {
+            _ = intv.tick() => {
+                let url = format!("https://api.stlouisfed.org/fred/series/observations?series_id=DGS10&sort_order=desc&limit=1&api_key={api_key}&file_type=json");
+                match client.get(&url).timeout(Duration::from_secs(10)).send().await {
+                    Ok(resp) => match resp.text().await {
+                        Ok(body) => match parse_fred_rate(&body) {
+                            Ok(Some(val)) => {
+                                let metric = MacroMetric {
+                                    category: "rate".into(),
+                                    symbol: "US10Y".into(),
+                                    value: val,
+                                    timestamp: Utc::now().timestamp_millis(),
+                                };
+                                let _ = tx.send(metric);
+                            }
+                            Ok(None) => info!("no rate data"),
+                            Err(e) => info!("rate parse error: {}", e),
+                        },
+                        Err(e) => info!("rate body error: {}", e),
+                    },
+                    Err(e) => info!("rate fetch error: {}", e),
+                }
+            }
+            _ = shutdown.cancelled() => break,
         }
     }
 }
 
-async fn run_commodity_fetcher(tx: broadcast::Sender<MacroMetric>) {
-    let client = reqwest::Client::new();
+async fn run_commodity_fetcher(
+    client: reqwest::Client,
+    tx: broadcast::Sender<MacroMetric>,
+    shutdown: CancellationToken,
+) {
     let mut intv = interval(Duration::from_secs(3600));
     loop {
-        intv.tick().await;
-        for (symbol, name) in [("gc.f", "GOLD"), ("cl.f", "WTI")] {
-            if let Ok(resp) = client
-                .get(format!("https://stooq.com/q/l/?s={}&i=d", symbol))
-                .send()
-                .await
-            {
-                if let Ok(body) = resp.text().await {
-                    if let Some(price) = parse_stooq_price(&body) {
-                        let metric = MacroMetric {
-                            category: "commodity".into(),
-                            symbol: name.into(),
-                            value: price,
-                            timestamp: Utc::now().timestamp_millis(),
-                        };
-                        let _ = tx.send(metric);
+        tokio::select! {
+            _ = intv.tick() => {
+                for (symbol, name) in [("gc.f", "GOLD"), ("cl.f", "WTI")] {
+                    if let Ok(resp) = client
+                        .get(format!("https://stooq.com/q/l/?s={}&i=d", symbol))
+                        .timeout(Duration::from_secs(10))
+                        .send()
+                        .await
+                    {
+                        if let Ok(body) = resp.text().await {
+                            if let Some(price) = parse_stooq_price(&body) {
+                                let metric = MacroMetric {
+                                    category: "commodity".into(),
+                                    symbol: name.into(),
+                                    value: price,
+                                    timestamp: Utc::now().timestamp_millis(),
+                                };
+                                let _ = tx.send(metric);
+                            }
+                        }
                     }
                 }
             }
+            _ = shutdown.cancelled() => break,
         }
     }
 }
 
-async fn run_equity_fetcher(tx: broadcast::Sender<MacroMetric>) {
-    let client = reqwest::Client::new();
+async fn run_equity_fetcher(
+    client: reqwest::Client,
+    tx: broadcast::Sender<MacroMetric>,
+    shutdown: CancellationToken,
+) {
     let mut intv = interval(Duration::from_secs(3600));
     loop {
-        intv.tick().await;
-        for (symbol, name) in [("^spx", "SPX"), ("^ndq", "NDQ"), ("^dji", "DJI")] {
-            if let Ok(resp) = client
-                .get(format!("https://stooq.com/q/l/?s={}&i=d", symbol))
-                .send()
-                .await
-            {
-                if let Ok(body) = resp.text().await {
-                    if let Some(level) = parse_stooq_price(&body) {
-                        let metric = MacroMetric {
-                            category: "equity".into(),
-                            symbol: name.into(),
-                            value: level,
-                            timestamp: Utc::now().timestamp_millis(),
-                        };
-                        let _ = tx.send(metric);
+        tokio::select! {
+            _ = intv.tick() => {
+                for (symbol, name) in [("^spx", "SPX"), ("^ndq", "NDQ"), ("^dji", "DJI")] {
+                    if let Ok(resp) = client
+                        .get(format!("https://stooq.com/q/l/?s={}&i=d", symbol))
+                        .timeout(Duration::from_secs(10))
+                        .send()
+                        .await
+                    {
+                        if let Ok(body) = resp.text().await {
+                            if let Some(level) = parse_stooq_price(&body) {
+                                let metric = MacroMetric {
+                                    category: "equity".into(),
+                                    symbol: name.into(),
+                                    value: level,
+                                    timestamp: Utc::now().timestamp_millis(),
+                                };
+                                let _ = tx.send(metric);
+                            }
+                        }
                     }
                 }
             }
+            _ = shutdown.cancelled() => break,
         }
     }
 }
 
-async fn run_event_fetcher(tx: broadcast::Sender<MacroMetric>) {
-    let client = reqwest::Client::new();
+async fn run_event_fetcher(
+    client: reqwest::Client,
+    tx: broadcast::Sender<MacroMetric>,
+    shutdown: CancellationToken,
+) {
     let mut intv = interval(Duration::from_secs(86400));
     loop {
-        intv.tick().await;
-        match client
-            .get("https://date.nager.at/api/v3/NextPublicHolidays/US")
-            .send()
-            .await
-        {
-            Ok(resp) => match resp.text().await {
-                Ok(body) => match parse_nager_events(&body) {
-                    Ok(events) => events.into_iter().for_each(|e| {
-                        let _ = tx.send(e);
-                    }),
-                    Err(e) => info!("event parse error: {}", e),
-                },
-                Err(e) => info!("event body error: {}", e),
-            },
-            Err(e) => info!("event fetch error: {}", e),
+        tokio::select! {
+            _ = intv.tick() => {
+                match client
+                    .get("https://date.nager.at/api/v3/NextPublicHolidays/US")
+                    .timeout(Duration::from_secs(10))
+                    .send()
+                    .await
+                {
+                    Ok(resp) => match resp.text().await {
+                        Ok(body) => match parse_nager_events(&body) {
+                            Ok(events) => events.into_iter().for_each(|e| {
+                                let _ = tx.send(e);
+                            }),
+                            Err(e) => info!("event parse error: {}", e),
+                        },
+                        Err(e) => info!("event body error: {}", e),
+                    },
+                    Err(e) => info!("event fetch error: {}", e),
+                }
+            }
+            _ = shutdown.cancelled() => break,
         }
     }
 }
 
-async fn run_crypto_indices_fetcher(tx: broadcast::Sender<CryptoIndex>) {
-    let client = reqwest::Client::new();
+async fn run_crypto_indices_fetcher(
+    client: reqwest::Client,
+    tx: broadcast::Sender<CryptoIndex>,
+    shutdown: CancellationToken,
+) {
     let mut intv = interval(Duration::from_secs(300));
     loop {
-        intv.tick().await;
-        match client
-            .get("https://api.coingecko.com/api/v3/global")
-            .send()
-            .await
-        {
-            Ok(resp) => match resp.text().await {
-                Ok(body) => match parse_coingecko_global(&body) {
-                    Ok(indices) => indices.into_iter().for_each(|i| {
-                        let _ = tx.send(i);
-                    }),
-                    Err(e) => info!("crypto index parse error: {}", e),
-                },
-                Err(e) => info!("crypto index body error: {}", e),
-            },
-            Err(e) => info!("crypto index fetch error: {}", e),
+        tokio::select! {
+            _ = intv.tick() => {
+                match client
+                    .get("https://api.coingecko.com/api/v3/global")
+                    .timeout(Duration::from_secs(10))
+                    .send()
+                    .await
+                {
+                    Ok(resp) => match resp.text().await {
+                        Ok(body) => match parse_coingecko_global(&body) {
+                            Ok(indices) => indices.into_iter().for_each(|i| {
+                                let _ = tx.send(i);
+                            }),
+                            Err(e) => info!("crypto index parse error: {}", e),
+                        },
+                        Err(e) => info!("crypto index body error: {}", e),
+                    },
+                    Err(e) => info!("crypto index fetch error: {}", e),
+                }
+            }
+            _ = shutdown.cancelled() => break,
         }
     }
 }
@@ -282,11 +364,7 @@ fn parse_nager_events(data: &str) -> Result<Vec<MacroMetric>, serde_json::Error>
     let mut res = Vec::new();
     for h in holidays {
         if let Ok(d) = NaiveDate::parse_from_str(&h.date, "%Y-%m-%d") {
-            let ts = d
-                .and_hms_opt(0, 0, 0)
-                .unwrap()
-                .and_utc()
-                .timestamp_millis();
+            let ts = d.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp_millis();
             res.push(MacroMetric {
                 category: "event".into(),
                 symbol: h.name,
@@ -307,16 +385,24 @@ mod tests {
         let json = r#"{"base":"USD","rates":{"EUR":0.9,"JPY":110.0}}"#;
         let metrics = parse_exchangerate_host(json).unwrap();
         assert_eq!(metrics.len(), 2);
-        assert!(metrics.iter().any(|m| m.symbol == "USDEUR" && (m.value - 0.9).abs() < 1e-6));
-        assert!(metrics.iter().any(|m| m.symbol == "USDJPY" && (m.value - 110.0).abs() < 1e-6));
+        assert!(metrics
+            .iter()
+            .any(|m| m.symbol == "USDEUR" && (m.value - 0.9).abs() < 1e-6));
+        assert!(metrics
+            .iter()
+            .any(|m| m.symbol == "USDJPY" && (m.value - 110.0).abs() < 1e-6));
     }
 
     #[test]
     fn parses_crypto_indices() {
         let json = r#"{"data":{"market_cap_percentage":{"btc":51.0,"eth":18.0}}}"#;
         let indices = parse_coingecko_global(json).unwrap();
-        assert!(indices.iter().any(|i| i.name == "btc_dominance" && (i.value - 51.0).abs() < 1e-6));
-        assert!(indices.iter().any(|i| i.name == "eth_dominance" && (i.value - 18.0).abs() < 1e-6));
+        assert!(indices
+            .iter()
+            .any(|i| i.name == "btc_dominance" && (i.value - 51.0).abs() < 1e-6));
+        assert!(indices
+            .iter()
+            .any(|i| i.name == "eth_dominance" && (i.value - 18.0).abs() < 1e-6));
     }
 
     #[test]

--- a/macro-data/src/main.rs
+++ b/macro-data/src/main.rs
@@ -1,15 +1,20 @@
 use macro_data::spawn;
 use tokio::signal;
+use tokio_util::sync::CancellationToken;
 
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
-    let (mut macro_rx, mut crypto_rx) = spawn();
+    let shutdown = CancellationToken::new();
+    let (mut macro_rx, mut crypto_rx) = spawn(shutdown.clone());
     loop {
         tokio::select! {
             Ok(metric) = macro_rx.recv() => println!("macro: {:?}", metric),
             Ok(index) = crypto_rx.recv() => println!("crypto: {:?}", index),
-            _ = signal::ctrl_c() => break,
+            _ = signal::ctrl_c() => {
+                shutdown.cancel();
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- create a single reqwest client with a global timeout and share it across macro data fetchers
- add per-request timeouts and CancellationToken-based shutdown handling

## Testing
- `cargo test -p macro-data`

------
https://chatgpt.com/codex/tasks/task_e_68b08c20c9148323a1732eb643b7c361