### PR TITLE
feat: make binance futures endpoints configurable

### DIFF
--- a/crypto-ingestor/src/agents/binance/open_interest_history.rs
+++ b/crypto-ingestor/src/agents/binance/open_interest_history.rs
@@ -23,7 +23,8 @@ const PERIOD: &str = "5m";
 /// Backfill historical open interest for `symbols` and publish events via `tx`.
 ///
 /// `symbols` should be lowercase Binance symbols (e.g. `btcusdt`).
-pub async fn backfill(symbols: &[String], tx: mpsc::Sender<String>) {
+/// `rest_url` is the base URL for Binance futures REST API.
+pub async fn backfill(symbols: &[String], rest_url: &str, tx: mpsc::Sender<String>) {
     let client = match http_client::builder().build() {
         Ok(c) => c,
         Err(e) => {
@@ -33,7 +34,7 @@ pub async fn backfill(symbols: &[String], tx: mpsc::Sender<String>) {
     };
 
     for sym in symbols {
-        if let Err(e) = backfill_symbol(&client, sym, &tx).await {
+        if let Err(e) = backfill_symbol(&client, rest_url, sym, &tx).await {
             tracing::error!(symbol=%sym, error=%e, "open interest history backfill failed");
         }
     }
@@ -41,13 +42,15 @@ pub async fn backfill(symbols: &[String], tx: mpsc::Sender<String>) {
 
 async fn backfill_symbol(
     client: &reqwest::Client,
+    rest_url: &str,
     symbol: &str,
     tx: &mpsc::Sender<String>,
 ) -> Result<(), reqwest::Error> {
     let mut start: i64 = 0;
     loop {
         let url = format!(
-            "https://fapi.binance.us/fapi/v1/openInterestHist?symbol={}&period={}&limit={}&startTime={}",
+            "{}/fapi/v1/openInterestHist?symbol={}&period={}&limit={}&startTime={}",
+            rest_url,
             symbol.to_uppercase(),
             PERIOD,
             LIMIT,

--- a/crypto-ingestor/src/config.rs
+++ b/crypto-ingestor/src/config.rs
@@ -99,6 +99,10 @@ pub struct Settings {
     pub binance_refresh_interval_mins: u64,
     pub binance_max_reconnect_delay_secs: u64,
     #[serde(default)]
+    pub binance_futures_rest_url: Option<String>,
+    #[serde(default)]
+    pub binance_futures_ws_url: Option<String>,
+    #[serde(default)]
     pub binance_options_rest_url: String,
     #[serde(default)]
     pub binance_options_symbols: Vec<String>,
@@ -196,6 +200,8 @@ impl Default for Settings {
             binance_ws_url: String::new(),
             binance_refresh_interval_mins: 60,
             binance_max_reconnect_delay_secs: 30,
+            binance_futures_rest_url: None,
+            binance_futures_ws_url: None,
             binance_options_rest_url: String::new(),
             binance_options_symbols: Vec::new(),
             binance_options_poll_interval_secs: 60,
@@ -242,6 +248,8 @@ impl Settings {
             .set_default("binance_ws_url", "wss://stream.binance.us:9443/ws")?
             .set_default("binance_refresh_interval_mins", 60)?
             .set_default("binance_max_reconnect_delay_secs", 30)?
+            .set_default("binance_futures_rest_url", "https://fapi.binance.com")?
+            .set_default("binance_futures_ws_url", "wss://fstream.binance.com")?
             .set_default(
                 "binance_options_rest_url",
                 "https://eapi.binance.us/eapi/v1",
@@ -317,6 +325,9 @@ impl Settings {
         settings.top_dex_pools = settings.top_dex_pools || cli.top_dex_pools;
         settings.news_headlines = settings.news_headlines || cli.news_headlines;
         settings.telemetry = settings.telemetry || cli.telemetry;
+        settings.binance_futures_rest_url =
+            settings.binance_futures_rest_url.filter(|s| !s.is_empty());
+        settings.binance_futures_ws_url = settings.binance_futures_ws_url.filter(|s| !s.is_empty());
         Ok(settings)
     }
 }


### PR DESCRIPTION
## Summary
- add configurable futures REST and websocket URLs for Binance
- default Binance futures requests to `fapi.binance.com`/`fstream.binance.com`
- skip futures backfill and streams when futures URLs are unset

## Testing
- `cargo -Znext-lockfile-bump check -p crypto-ingestor` *(fails: feature `edition2024` is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e64375088323a5d3419a70ec7640