### PR TITLE
Respect open interest flag for Binance

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ runtime. Each feed is enabled via a dedicated command-line flag:
 - `--news-headlines` – crypto news headlines
 - `--telemetry` – system telemetry events
 
+Open interest streams are disabled by default and must be explicitly enabled
+with `--open-interest`.
+
 Example enabling trades and the 24h ticker:
 
 ```bash


### PR DESCRIPTION
## Summary
- make Binance open interest streaming optional via config
- document that open interest streams are disabled by default

## Testing
- `cargo test -p ingestor` *(fails: binance_trade_messages_are_canonicalized_with_id)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ee344408832393aa00e3ce2662ae