### PR TITLE
chore: document crate inventory

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,0 +1,9 @@
+# Summary
+- cataloged workspace crates, targets, and dependencies.
+- mapped ingest, normalize, validate touchpoints in `docs/CRATE_MAP.md`.
+- recorded keep/remove decisions in `docs/KEEP_REMOVE.md`.
+
+# Testing
+- `cargo fmt`
+- `cargo clippy -- -D warnings` *(fails: unnecessary_sort_by in canonicalizer)*
+- `cargo build`

--- a/docs/CRATE_MAP.md
+++ b/docs/CRATE_MAP.md
@@ -1,0 +1,102 @@
+# Crate Map
+
+## Workspace Members
+- `crypto-ingestor` – binary crate providing exchange ingestion agents.
+- `canonicalizer` – library and binary for symbol/event normalization.
+- `analytics` – library and binary with downstream analytics.
+- `on-chain` – library with on-chain normalization helpers.
+- `signals` – library fetching news/social/dev activity.
+- `onchain-ingestor` – binary for Ethereum event ingestion.
+- `macro-data` – library and binary for macroeconomic data fetchers.
+
+## Crate Details
+
+### crypto-ingestor
+*Targets*: bin `ingestor` (`src/main.rs`)
+
+*Dependencies*: tokio 1, tokio-tungstenite 0.21, futures-util 0.3, serde 1, serde_json 1, async-trait 0.1,
+reqwest 0.11, tracing 0.1, tracing-subscriber 0.3, chrono 0.4, canonicalizer (path), ntp 0.4,
+time 0.1, hmac 0.12, sha2 0.10, hex 0.4, prometheus 0.13, hyper 0.14, once_cell 1, axum 0.6,
+clap 4, config 0.13, rust_decimal 1, thiserror 1, metrics 0.21, rdkafka 0.36, ethers 2.
+
+*Modules*:
+- `agent` – defines `Agent` trait for ingestion workers.
+- `agents` – factories for exchange adapters.
+    - `binance`, `coinbase` – websocket agents emitting raw frames (use `CanonicalService`).
+    - `deribit`, `onchain` – additional agents.
+- `sink` – `OutputSink` trait with `StdoutSink`, `FileSink`, `KafkaSink`.
+- `config` – CLI & settings controlling which feeds run.
+- `metrics`, `clock`, `http_client`, `labels`, `metadata`, `parse`, `error` – helpers.
+
+*Ingest implementations*: `agent` and `agents/*`.
+
+*Normalization calls*: agents use `canonicalizer::CanonicalService`.
+
+*Validator usage*: none present.
+
+### canonicalizer
+*Targets*: lib + bin
+
+*Dependencies*: tokio 1, reqwest 0.11, serde 1, serde_json 1, tabwriter 1, tracing 0.1, ethers-core 2.
+
+*Modules*:
+- `lib` – `CanonicalService` and event types (`L2Diff`, etc.).
+- `events` – additional canonical structs (`Bar`, `Order`, ...).
+- `http_client` – helper to build TLS HTTP client.
+- `onchain` – formatting for on-chain transactions/logs.
+
+*Normalization implementations*: `CanonicalService::canonical_pair`, `onchain::format_*`.
+
+*Direct callers*: `crypto-ingestor` agents, `onchain-ingestor`.
+
+### analytics
+*Targets*: lib + bin
+
+*Dependencies*: tokio 1, serde 1, serde_json 1, tracing 0.1, tracing-subscriber 0.3,
+canonicalizer (path), ordered-float 3, chrono 0.4.
+
+*Modules*: `defi_metrics`, `monitor`, `orderbook`, `risk`.
+
+*Calls*: consumes canonical trade events for monitoring; no ingest/normalize/validate traits.
+
+### on-chain
+*Target*: lib
+
+*Dependencies*: serde 1, serde_json 1, chrono 0.4, async-trait 0.1, reqwest 0.11,
+thiserror 1, tokio 1.
+
+*Modules*: `lib` defining `PoolState`, `DexSwap`, `OraclePrice`, `Oracle` trait,
+`normalize_pool_state`, `normalize_swap`, and oracle helpers.
+
+*Normalization implementations*: `normalize_pool_state`, `normalize_swap`.
+
+### signals
+*Target*: lib
+
+*Dependencies*: reqwest 0.11, tokio 1, serde 1, serde_json 1, chrono 0.4.
+
+*Module*: `lib` with `fetch_news`, `fetch_reddit_metric`, `fetch_twitter_metric`,
+`fetch_github_activity`, etc. No ingest/normalize/validate traits.
+
+### onchain-ingestor
+*Target*: bin
+
+*Dependencies*: tokio 1, ethers 2 (ws), serde 1, serde_json 1, clap 4, async-trait 0.1,
+rdkafka 0.36, canonicalizer (path), anyhow 1.
+
+*Modules*: `main` – subscribes to Ethereum blocks/logs and outputs
+canonical JSON via sinks; `sink` – defines `DynSink`, `KafkaSink`, `StdoutSink`.
+
+*Ingest implementations*: `main` uses websocket provider to ingest on-chain data.
+
+### macro-data
+*Targets*: lib + bin
+
+*Dependencies*: tokio 1, reqwest 0.11, serde 1, serde_json 1, chrono 0.4,
+tracing 0.1, tracing-subscriber 0.3, tokio-util 0.7.
+
+*Modules*: `lib` spawning periodic fetchers for macro metrics
+and crypto indices.
+
+No ingest/normalize/validate traits.
+

--- a/docs/KEEP_REMOVE.md
+++ b/docs/KEEP_REMOVE.md
@@ -1,0 +1,22 @@
+# Keep/Remove Plan
+
+| Item | Decision | Reason |
+| --- | --- | --- |
+| `crypto-ingestor` crate | KEEP | Core exchange ingestion pipeline. |
+| `canonicalizer` crate | KEEP | Provides symbol and event normalization. |
+| `analytics` crate | REMOVE | Downstream analysis beyond ingest/normalize/validate. |
+| `on-chain` crate | REMOVE | On-chain helpers not needed for core trade pipeline. |
+| `signals` crate | REMOVE | News and sentiment data outside core scope. |
+| `onchain-ingestor` crate | REMOVE | Separate on-chain ingestion; non-core. |
+| `macro-data` crate | REMOVE | Macroeconomic data fetchers; out of scope. |
+| `crypto-ingestor/agents/binance` | KEEP | Needed exchange adapter. |
+| `crypto-ingestor/agents/coinbase` | KEEP | Needed exchange adapter. |
+| `crypto-ingestor/agents/deribit` | REMOVE | Options ingestion; non-core. |
+| `crypto-ingestor/agents/onchain` | REMOVE | On-chain transfers; non-core. |
+| `crypto-ingestor/sink::StdoutSink` | KEEP | Minimal emit path. |
+| `crypto-ingestor/sink::FileSink` | REMOVE | File output not required. |
+| `crypto-ingestor/sink::KafkaSink` | REMOVE | External bus/outbox. |
+| `crypto-ingestor/metrics` | REMOVE | Prometheus metrics server. |
+| `crypto-ingestor/config` extra flags | STUB | Many feature toggles to be pruned later. |
+| `canonicalizer/onchain` | STUB | Used only by on-chain ingestion; revisit after removing onchain-ingestor. |
+| Validator trait | STUB | Not yet defined; will be introduced in later step. |


### PR DESCRIPTION
## Summary
- add CRATE_MAP outlining workspace crates, modules, and public APIs
- add KEEP_REMOVE plan with decisions for each crate/module
- record testing and planning in SUMMARY

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings` *(fails: unnecessary_sort_by in canonicalizer)*
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68b0f18d1de483239f5efd4c310d3241