### PR TITLE
Remove file sink and configuration options

### DIFF
--- a/crypto-ingestor/src/config.rs
+++ b/crypto-ingestor/src/config.rs
@@ -12,14 +12,6 @@ pub struct Cli {
     #[arg(short, long)]
     pub config: Option<String>,
 
-    /// Output sink type (stdout, file)
-    #[arg(long, default_value = "stdout")]
-    pub sink: String,
-
-    /// Output file path
-    #[arg(long)]
-    pub file_path: Option<String>,
-
     /// Enable trade feeds
     #[arg(long)]
     pub trades: bool,
@@ -111,11 +103,6 @@ pub struct Settings {
     pub coinbase_api_key: Option<String>,
     #[serde(default)]
     pub coinbase_api_secret: Option<String>,
-    #[serde(default = "default_sink")]
-    pub sink: String,
-    #[serde(default)]
-    pub file_path: Option<String>,
-
     #[serde(default)]
     pub trades: bool,
     #[serde(default)]
@@ -142,10 +129,6 @@ pub struct Settings {
     pub news_headlines: bool,
     #[serde(default)]
     pub telemetry: bool,
-}
-
-fn default_sink() -> String {
-    "stdout".into()
 }
 
 fn default_binance_options_poll_interval_secs() -> u64 {
@@ -182,8 +165,6 @@ impl Default for Settings {
             binance_api_secret: None,
             coinbase_api_key: None,
             coinbase_api_secret: None,
-            sink: default_sink(),
-            file_path: None,
             trades: false,
             l2_diffs: false,
             l2_snapshots: false,
@@ -224,7 +205,6 @@ impl Settings {
             .set_default("coinbase_max_reconnect_delay_secs", 30)?
             .set_default("coinbase_ohlcv_poll_interval_secs", 60)?
             .set_default("coinbase_ohlcv_intervals", vec![60])?
-            .set_default("sink", "stdout")?
             .set_default("trades", false)?
             .set_default("l2_diffs", false)?
             .set_default("l2_snapshots", false)?
@@ -244,11 +224,6 @@ impl Settings {
         }
         let cfg = builder.build()?;
         let mut settings: Settings = cfg.try_deserialize()?;
-        settings.sink = cli.sink.clone();
-
-        if let Some(p) = &cli.file_path {
-            settings.file_path = Some(p.clone());
-        }
         // populate API keys from environment if not set in config
         settings.binance_api_key = settings
             .binance_api_key

--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -13,7 +13,7 @@ use canonicalizer::CanonicalService;
 use clap::Parser;
 use config::{Cli, Settings};
 use error::IngestorError;
-use sink::{DynSink, FileSink, StdoutSink};
+use sink::{DynSink, StdoutSink};
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::process::Command;
@@ -45,22 +45,7 @@ async fn main() -> Result<(), IngestorError> {
     clock::spawn_clock_sync();
 
     // initialise output sink
-    let sink: DynSink = match settings.sink.as_str() {
-        "stdout" => Arc::new(StdoutSink::new()),
-        "file" => {
-            let path = settings
-                .file_path
-                .as_ref()
-                .ok_or_else(|| IngestorError::Other("file_path not set".into()))?;
-            Arc::new(FileSink::new(path).await.map_err(IngestorError::Io)?)
-        }
-        other => {
-            return Err(IngestorError::Other(format!(
-                "unknown sink type: {}",
-                other
-            )));
-        }
-    };
+    let sink: DynSink = Arc::new(StdoutSink::new());
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 

--- a/crypto-ingestor/src/sink.rs
+++ b/crypto-ingestor/src/sink.rs
@@ -33,30 +33,3 @@ impl OutputSink for StdoutSink {
         Ok(())
     }
 }
-
-pub struct FileSink {
-    file: Mutex<tokio::fs::File>,
-}
-
-impl FileSink {
-    pub async fn new(path: &str) -> Result<Self, std::io::Error> {
-        let file = tokio::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-            .await?;
-        Ok(Self {
-            file: Mutex::new(file),
-        })
-    }
-}
-
-#[async_trait]
-impl OutputSink for FileSink {
-    async fn send(&self, line: &str) -> Result<(), IngestorError> {
-        let mut file = self.file.lock().await;
-        file.write_all(line.as_bytes()).await?;
-        file.write_all(b"\n").await?;
-        Ok(())
-    }
-}


### PR DESCRIPTION
## Summary
- remove FileSink and file-based output configuration
- drop sink and file_path options from CLI and settings
- default to StdoutSink for all output

## Testing
- `cargo test -p ingestor` *(failed: hung, terminated)*
- `cargo check -p ingestor`


------
https://chatgpt.com/codex/tasks/task_e_68b39eecd6808323a29a71b97e355b08