### PR TITLE
Remove unused feed toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,42 +16,13 @@ This repository is organised as a Cargo workspace containing several crates:
 - `binance` – streams trade data for selected symbols via WebSocket.
 - `coinbase` – streams trade data for selected pairs via WebSocket.
 
-## Phase 1 feeds
+## Feeds
 
-`crypto-ingestor` can toggle a variety of market and auxiliary data streams at
-runtime. Each feed is enabled via a dedicated command-line flag:
-
-- `--trades` – raw trade data
-- `--l2-diffs` – incremental order book updates
-- `--l2-snapshots` – full order book snapshots
-- `--book-ticker` – best bid/ask updates
-- `--ticker-24h` – rolling 24‑hour ticker
-- `--ohlcv` – candlestick data
-- `--index-price` – index prices
-- `--mark-price` – futures mark prices
-- `--funding-rates` – funding rate changes
-- `--open-interest` – open interest statistics
-- `--top-dex-pools` – top DEX pool prices
-- `--news-headlines` – crypto news headlines
-- `--telemetry` – system telemetry events
-
-Open interest streams are disabled by default and must be explicitly enabled
-with `--open-interest`.
-Futures backfills accept base assets or common pair formats and normalise them
-to the required Binance symbol. For example `btc` becomes `BTCUSDT` for
-USDT‑margined contracts or `BTCUSD_PERP` when using the coin‑M API. Pairs that
-cannot be normalised are skipped with a warning.
-
-Example enabling trades and the 24h ticker:
+The ingestor currently supports streaming raw trade data. Enable the trade feed
+with the `--trades` flag:
 
 ```bash
-cargo run --release -- --trades --ticker-24h binance:btcusdt
-```
-
-Example fetching funding rates and open interest for BTC futures:
-
-```bash
-cargo run --release -- --funding-rates --open-interest binance:btc
+cargo run --release -- --trades binance:btcusdt
 ```
 
 ## Canonicalizer

--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -19,7 +19,7 @@ use super::{shared_symbols, AgentFactory};
 use canonicalizer::CanonicalService;
 
 const MAX_STREAMS_PER_CONN: usize = 1024; // per Binance docs
-const STREAMS_PER_SYMBOL: usize = 3; // trade, depth diff, book ticker
+const STREAMS_PER_SYMBOL: usize = 1; // trade only
 
 /// Fetch all tradable symbols from Binance US REST API.
 pub async fn fetch_all_symbols() -> Result<Vec<String>, IngestorError> {
@@ -77,7 +77,6 @@ pub struct BinanceAgent {
     refresh_interval_mins: u64,
     futures_ws_url: Option<String>,
     futures_rest_url: Option<String>,
-    open_interest: bool,
 }
 
 impl BinanceAgent {
@@ -94,7 +93,6 @@ impl BinanceAgent {
             refresh_interval_mins: cfg.binance_refresh_interval_mins,
             futures_ws_url: cfg.binance_futures_ws_url.clone(),
             futures_rest_url: cfg.binance_futures_rest_url.clone(),
-            open_interest: cfg.open_interest,
         })
     }
 }
@@ -131,54 +129,6 @@ impl Agent for BinanceAgent {
             let tx_clone = out_tx.clone();
             handles.push(tokio::spawn(async move {
                 connection_task(rx, shutdown_rx, tx_clone, ws_url, max_delay).await;
-            }));
-        }
-        // additional aggregated streams not tied to symbol subsets
-        if let Some(ws_url) = &self.futures_ws_url {
-            let shutdown_clone = shutdown.clone();
-            let tx_clone = out_tx.clone();
-            let url = ws_url.clone();
-            handles.push(tokio::spawn(async move {
-                mark_price_task(&url, shutdown_clone, tx_clone).await;
-            }));
-
-            let shutdown_clone = shutdown.clone();
-            let tx_clone = out_tx.clone();
-            let url = ws_url.clone();
-            handles.push(tokio::spawn(async move {
-                funding_rate_task(&url, shutdown_clone, tx_clone).await;
-            }));
-
-            if self.open_interest {
-                let shutdown_clone = shutdown.clone();
-                let tx_clone = out_tx.clone();
-                let url = ws_url.clone();
-                handles.push(tokio::spawn(async move {
-                    open_interest_task(&url, shutdown_clone, tx_clone).await;
-                }));
-            }
-
-            let shutdown_clone = shutdown.clone();
-            let tx_clone = out_tx.clone();
-            let url = ws_url.clone();
-            handles.push(tokio::spawn(async move {
-                liquidation_task(&url, shutdown_clone, tx_clone).await;
-            }));
-        }
-
-        if let Some(rest_url) = &self.futures_rest_url {
-            let symbols_clone = self.symbols.clone();
-            let shutdown_clone = shutdown.clone();
-            let tx_clone = out_tx.clone();
-            let url = rest_url.clone();
-            handles.push(tokio::spawn(async move {
-                term_structure_task(symbols_clone, &url, shutdown_clone, tx_clone).await;
-            }));
-        }
-        for sym in self.symbols.clone() {
-            let tx_clone = out_tx.clone();
-            handles.push(tokio::spawn(async move {
-                snapshot_task(sym, tx_clone).await;
             }));
         }
 
@@ -380,31 +330,23 @@ async fn connection_task(
                                                     .filter(|id| *id > 0);
                                                 if let Some(id) = trade_id {
                                                     if let Some(last) = last_trade_ids.get_mut(&sym) {
-                                                      *last = id;
+                                                        *last = id;
                                                     } else {
                                                         last_trade_ids.insert(sym.clone(), id);
                                                     }
                                                 }
-                                                let px = match v
+                                                let px = v
                                                     .get("p")
                                                     .and_then(|p| p.as_str())
                                                     .and_then(parse_decimal_str)
-                                                {
-                                                    Some(p) => p,
-                                                    None => {                                                        "?".to_string()
-                                                    }
-                                                };
-                                                let qty = match v
+                                                    .unwrap_or_else(|| "?".to_string());
+                                                let qty = v
                                                     .get("q")
                                                     .and_then(|q| q.as_str())
                                                     .and_then(parse_decimal_str)
-                                                {
-                                                    Some(q) => q,
-                                                    None => {                                                        "?".to_string()
-                                                    }
-                                                };
-                                                  let ts = v.get("T").and_then(|x| x.as_i64()).unwrap_or_default();
-                                                  let skew = clock::current_skew_ms();
+                                                    .unwrap_or_else(|| "?".to_string());
+                                                let ts = v.get("T").and_then(|x| x.as_i64()).unwrap_or_default();
+                                                let skew = clock::current_skew_ms();
                                                 let line = serde_json::json!({
                                                     "agent": "binance",
                                                     "type": "trade",
@@ -416,81 +358,9 @@ async fn connection_task(
                                                     "skew": skew
                                                 })
                                                 .to_string();
-                                                  if tx.send(line).await.is_err() {
-                                                      break;
-                                                  }
-                                            }
-                                            "depthUpdate" => {
-                                                let bids = v
-                                                    .get("b")
-                                                    .and_then(|b| b.as_array())
-                                                    .cloned()
-                                                    .unwrap_or_default()
-                                                    .into_iter()
-                                                    .filter_map(|lvl| {
-                                                        let p = lvl.get(0)?.as_str()?.to_string();
-                                                        let q = lvl.get(1)?.as_str()?.to_string();
-                                                        Some([p, q])
-                                                    })
-                                                    .collect::<Vec<[String;2]>>();
-                                                let asks = v
-                                                    .get("a")
-                                                    .and_then(|a| a.as_array())
-                                                    .cloned()
-                                                    .unwrap_or_default()
-                                                    .into_iter()
-                                                    .filter_map(|lvl| {
-                                                        let p = lvl.get(0)?.as_str()?.to_string();
-                                                        let q = lvl.get(1)?.as_str()?.to_string();
-                                                        Some([p, q])
-                                                    })
-                                                    .collect::<Vec<[String;2]>>();
-                                                let ts = v.get("E").and_then(|x| x.as_i64()).unwrap_or_default();
-                                                let line = serde_json::json!({
-                                                    "agent": "binance",
-                                                    "type": "l2_diff",
-                                                    "s": sym,
-                                                    "bids": bids,
-                                                    "asks": asks,
-                                                    "ts": ts
-                                                }).to_string();
-                                                if tx.send(line).await.is_ok() {
-                                                } else { break; }
-                                            }
-                                            "bookTicker" => {
-                                                let bid_px = v
-                                                    .get("b")
-                                                    .and_then(|p| p.as_str())
-                                                    .and_then(parse_decimal_str)
-                                                    .unwrap_or_else(|| "?".to_string());
-                                                let bid_qty = v
-                                                    .get("B")
-                                                    .and_then(|q| q.as_str())
-                                                    .and_then(parse_decimal_str)
-                                                    .unwrap_or_else(|| "?".to_string());
-                                                let ask_px = v
-                                                    .get("a")
-                                                    .and_then(|p| p.as_str())
-                                                    .and_then(parse_decimal_str)
-                                                    .unwrap_or_else(|| "?".to_string());
-                                                let ask_qty = v
-                                                    .get("A")
-                                                    .and_then(|q| q.as_str())
-                                                    .and_then(parse_decimal_str)
-                                                    .unwrap_or_else(|| "?".to_string());
-                                                let ts = v.get("E").and_then(|x| x.as_i64()).unwrap_or_default();
-                                                let line = serde_json::json!({
-                                                    "agent": "binance",
-                                                    "type": "book_ticker",
-                                                    "s": sym,
-                                                    "bp": bid_px,
-                                                    "bq": bid_qty,
-                                                    "ap": ask_px,
-                                                    "aq": ask_qty,
-                                                    "ts": ts
-                                                }).to_string();
-                                                if tx.send(line).await.is_ok() {
-                                                } else { break; }
+                                                if tx.send(line).await.is_err() {
+                                                    break;
+                                                }
                                             }
                                             _ => {}
                                         }
@@ -531,86 +401,13 @@ async fn connection_task(
     }
 }
 
-async fn snapshot_task(symbol: String, tx: mpsc::Sender<String>) {
-    let client = match http_client::builder().build() {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::error!(error=%e, "binance snapshot http client");
-            return;
-        }
-    };
-    let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
-    loop {
-        let url = format!(
-            "https://api.binance.us/api/v3/depth?symbol={}&limit=1000",
-            symbol.to_uppercase()
-        );
-        match client.get(&url).send().await {
-            Ok(resp) => match resp.json::<serde_json::Value>().await {
-                Ok(v) => {
-                    let bids = v
-                        .get("bids")
-                        .and_then(|b| b.as_array())
-                        .cloned()
-                        .unwrap_or_default()
-                        .into_iter()
-                        .filter_map(|lvl| {
-                            let p = lvl.get(0)?.as_str()?.to_string();
-                            let q = lvl.get(1)?.as_str()?.to_string();
-                            Some([p, q])
-                        })
-                        .collect::<Vec<[String; 2]>>();
-                    let asks = v
-                        .get("asks")
-                        .and_then(|b| b.as_array())
-                        .cloned()
-                        .unwrap_or_default()
-                        .into_iter()
-                        .filter_map(|lvl| {
-                            let p = lvl.get(0)?.as_str()?.to_string();
-                            let q = lvl.get(1)?.as_str()?.to_string();
-                            Some([p, q])
-                        })
-                        .collect::<Vec<[String; 2]>>();
-                    let sym = CanonicalService::canonical_pair("binance", &symbol)
-                        .unwrap_or_else(|| symbol.clone());
-                    let ts = chrono::Utc::now().timestamp_millis();
-                    let line = serde_json::json!({
-                        "agent": "binance",
-                        "type": "snapshot",
-                        "s": sym,
-                        "bids": bids,
-                        "asks": asks,
-                        "ts": ts
-                    })
-                    .to_string();
-                    let _ = tx.send(line).await;
-                }
-                Err(e) => {
-                    tracing::error!(error=%e, symbol=%symbol, "snapshot parse failed");
-                }
-            },
-            Err(e) => {
-                tracing::error!(error=%e, symbol=%symbol, "snapshot failed");
-            }
-        }
-        interval.tick().await;
-    }
-}
-
 async fn send_subscribe(
     ws: &mut WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>,
     symbols: &[String],
 ) -> Result<(), tokio_tungstenite::tungstenite::Error> {
     let params = symbols
         .iter()
-        .flat_map(|s| {
-            [
-                format!("{}@trade", s),
-                format!("{}@depth@100ms", s),
-                format!("{}@bookTicker", s),
-            ]
-        })
+        .map(|s| format!("{}@trade", s))
         .collect::<Vec<_>>();
     let sub_msg = serde_json::json!({
         "method": "SUBSCRIBE",
@@ -629,13 +426,7 @@ async fn send_unsubscribe(
     }
     let params = symbols
         .iter()
-        .flat_map(|s| {
-            [
-                format!("{}@trade", s),
-                format!("{}@depth@100ms", s),
-                format!("{}@bookTicker", s),
-            ]
-        })
+        .map(|s| format!("{}@trade", s))
         .collect::<Vec<_>>();
     let msg = serde_json::json!({
         "method": "UNSUBSCRIBE",
@@ -643,249 +434,4 @@ async fn send_unsubscribe(
         "id": 1,
     });
     ws.send(Message::Text(msg.to_string())).await
-}
-
-async fn mark_price_task(
-    base_ws_url: &str,
-    shutdown: tokio::sync::watch::Receiver<bool>,
-    tx: mpsc::Sender<String>,
-) {
-    let url = format!("{}/stream?streams=!markPrice@arr", base_ws_url);
-    aggregated_ws_loop(&url, "mark_price", shutdown, tx, |item| {
-        let raw = item.get("s").and_then(|s| s.as_str()).unwrap_or("?");
-        let sym =
-            CanonicalService::canonical_pair("binance", raw).unwrap_or_else(|| raw.to_string());
-        let price = item
-            .get("p")
-            .and_then(|p| p.as_str())
-            .and_then(parse_decimal_str)
-            .unwrap_or_else(|| "?".to_string());
-        let ts = item.get("E").and_then(|x| x.as_i64()).unwrap_or_default();
-        let line = serde_json::json!({
-            "agent": "binance",
-            "type": "mark_price",
-            "s": sym,
-            "p": price,
-            "ts": ts
-        })
-        .to_string();
-        (line, ts)
-    })
-    .await;
-}
-
-async fn funding_rate_task(
-    base_ws_url: &str,
-    shutdown: tokio::sync::watch::Receiver<bool>,
-    tx: mpsc::Sender<String>,
-) {
-    let url = format!("{}/stream?streams=!fundingRate@arr", base_ws_url);
-    aggregated_ws_loop(&url, "funding", shutdown, tx, |item| {
-        let raw = item.get("s").and_then(|s| s.as_str()).unwrap_or("?");
-        let sym =
-            CanonicalService::canonical_pair("binance", raw).unwrap_or_else(|| raw.to_string());
-        let rate = item
-            .get("r")
-            .and_then(|p| p.as_str())
-            .and_then(parse_decimal_str)
-            .unwrap_or_else(|| "?".to_string());
-        let ts = item.get("T").and_then(|x| x.as_i64()).unwrap_or_default();
-        let line = serde_json::json!({
-            "agent": "binance",
-            "type": "funding",
-            "s": sym,
-            "r": rate,
-            "ts": ts
-        })
-        .to_string();
-        (line, ts)
-    })
-    .await;
-}
-
-async fn open_interest_task(
-    base_ws_url: &str,
-    shutdown: tokio::sync::watch::Receiver<bool>,
-    tx: mpsc::Sender<String>,
-) {
-    let url = format!("{}/stream?streams=!openInterest@arr", base_ws_url);
-    aggregated_ws_loop(&url, "open_interest", shutdown, tx, |item| {
-        let raw = item.get("s").and_then(|s| s.as_str()).unwrap_or("?");
-        let sym =
-            CanonicalService::canonical_pair("binance", raw).unwrap_or_else(|| raw.to_string());
-        let oi = item
-            .get("oi")
-            .and_then(|p| p.as_str())
-            .and_then(parse_decimal_str)
-            .unwrap_or_else(|| "?".to_string());
-        let ts = item.get("T").and_then(|x| x.as_i64()).unwrap_or_default();
-        let line = serde_json::json!({
-            "agent": "binance",
-            "type": "open_interest",
-            "s": sym,
-            "oi": oi,
-            "ts": ts
-        })
-        .to_string();
-        (line, ts)
-    })
-    .await;
-}
-
-async fn liquidation_task(
-    base_ws_url: &str,
-    shutdown: tokio::sync::watch::Receiver<bool>,
-    tx: mpsc::Sender<String>,
-) {
-    let url = format!("{}/stream?streams=!forceOrder@arr", base_ws_url);
-    aggregated_ws_loop(&url, "liquidation", shutdown, tx, |item| {
-        let raw = item.get("s").and_then(|s| s.as_str()).unwrap_or("?");
-        let sym =
-            CanonicalService::canonical_pair("binance", raw).unwrap_or_else(|| raw.to_string());
-        let o = item.get("o").and_then(|o| o.as_object());
-        let price = o
-            .and_then(|m| m.get("p"))
-            .and_then(|p| p.as_str())
-            .and_then(parse_decimal_str)
-            .unwrap_or_else(|| "?".to_string());
-        let qty = o
-            .and_then(|m| m.get("q"))
-            .and_then(|p| p.as_str())
-            .and_then(parse_decimal_str)
-            .unwrap_or_else(|| "?".to_string());
-        let side = o
-            .and_then(|m| m.get("S"))
-            .and_then(|s| s.as_str())
-            .unwrap_or("?")
-            .to_string();
-        let ts = item.get("E").and_then(|x| x.as_i64()).unwrap_or_default();
-        let line = serde_json::json!({
-            "agent": "binance",
-            "type": "liquidation",
-            "s": sym,
-            "p": price,
-            "q": qty,
-            "side": side,
-            "ts": ts
-        })
-        .to_string();
-        (line, ts)
-    })
-    .await;
-}
-
-async fn term_structure_task(
-    symbols: Vec<String>,
-    rest_url: &str,
-    mut shutdown: tokio::sync::watch::Receiver<bool>,
-    tx: mpsc::Sender<String>,
-) {
-    let client = match http_client::builder().build() {
-        Ok(c) => c,
-        Err(_) => return,
-    };
-    let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
-    loop {
-        tokio::select! {
-            _ = shutdown.changed() => {
-                if *shutdown.borrow() { break; }
-            }
-            _ = interval.tick() => {
-                for sym in &symbols {
-                    let url = format!("{}/futures/data/basis?symbol={}&period=5m&limit=1", rest_url, sym.to_uppercase());
-                    if let Ok(resp) = client.get(&url).send().await {
-                        if let Ok(resp) = resp.json::<serde_json::Value>().await {
-                            if let Some(arr) = resp.as_array().and_then(|a| a.first()) {
-                                let raw = arr.get("symbol").and_then(|s| s.as_str()).unwrap_or("?");
-                                let canon = CanonicalService::canonical_pair("binance", raw).unwrap_or_else(|| raw.to_string());
-                                let basis = arr
-                                    .get("basis")
-                                    .and_then(|b| b.as_str())
-                                    .and_then(parse_decimal_str)
-                                    .unwrap_or_else(|| "?".to_string());
-                                let ts = arr.get("timestamp").and_then(|t| t.as_i64()).unwrap_or_default();
-                                let line = serde_json::json!({
-                                    "agent": "binance",
-                                    "type": "term",
-                                    "s": canon,
-                                    "b": basis,
-                                    "ts": ts
-                                }).to_string();
-                                let _ = tx.send(line).await;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-async fn aggregated_ws_loop<F>(
-    url: &str,
-    _metric: &str,
-    mut shutdown: tokio::sync::watch::Receiver<bool>,
-    tx: mpsc::Sender<String>,
-    mut build: F,
-) where
-    F: FnMut(&serde_json::Value) -> (String, i64),
-{
-    let mut attempt: u32 = 0;
-    loop {
-        if *shutdown.borrow() {
-            break;
-        }
-        tracing::info!(%url, "connecting");
-        match connect_async(url).await {
-            Ok((mut ws, _)) => {
-                attempt = 0;
-                loop {
-                    tokio::select! {
-                        _ = shutdown.changed() => {
-                            if *shutdown.borrow() {
-                                let _ = ws.close(None).await;
-                                return;
-                            }
-                        }
-                        msg = ws.next() => {
-                            match msg {
-                                Some(Ok(Message::Text(txt))) => {
-                                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&txt) {
-                                        if let Some(arr) = v.get("data").and_then(|d| d.as_array()) {
-                                            for item in arr {
-                                                let (line, _ts) = build(item);
-                                                let _ = tx.send(line).await;
-                                            }
-                                        }
-                                    }
-                                },
-                                Some(Ok(Message::Ping(p))) => { let _ = ws.send(Message::Pong(p)).await; }
-                                Some(Ok(Message::Close(_))) => { break; }
-                                Some(Ok(_)) => {}
-                                Some(Err(e)) => { tracing::error!(error=%e, "ws error"); break; }
-                                None => { break; }
-                            }
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                tracing::error!(error=%e, "connect failed");
-            }
-        }
-
-        attempt = attempt.saturating_add(1);
-        let exp: u32 = attempt.saturating_sub(1).min(4);
-        let delay = (1u64 << exp).min(16);
-        let sleep = std::time::Duration::from_secs(delay);
-        tracing::info!(?sleep, "reconnecting");
-        tokio::select! {
-            _ = tokio::time::sleep(sleep) => {},
-            _ = shutdown.changed() => {
-                if *shutdown.borrow() {
-                    break;
-                }
-            }
-        }
-    }
 }

--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -1,12 +1,11 @@
 use futures_util::{SinkExt, StreamExt};
 pub mod metadata;
 pub mod ohlcv;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
 
 use super::{shared_symbols, AgentFactory};
-use crate::clock;
 use crate::{
     agent::Agent,
     config::Settings,
@@ -87,7 +86,6 @@ impl Agent for CoinbaseAgent {
     ) -> Result<(), IngestorError> {
         let mut handle = None;
         let mut sym_tx = None;
-        let mut snap_handles = Vec::new();
 
         if !self.symbols.is_empty() {
             let (s_tx, rx) = tokio::sync::watch::channel(self.symbols.clone());
@@ -99,12 +97,6 @@ impl Agent for CoinbaseAgent {
             handle = Some(tokio::spawn(async move {
                 connection_task(rx, shutdown_rx, tx_clone, ws_url, max_delay).await;
             }));
-            for sym in self.symbols.clone() {
-                let tx_snap = tx.clone();
-                snap_handles.push(tokio::spawn(async move {
-                    snapshot_task(sym, tx_snap).await;
-                }));
-            }
         }
 
         let mut refresh = tokio::time::interval(std::time::Duration::from_secs(
@@ -165,36 +157,8 @@ impl Agent for CoinbaseAgent {
         if let Some(h) = handle {
             let _ = h.await;
         }
-        for h in snap_handles {
-            let _ = h.await;
-        }
 
         Ok(())
-    }
-}
-
-pub struct CoinbaseFactory;
-
-#[async_trait::async_trait]
-impl AgentFactory for CoinbaseFactory {
-    async fn create(&self, spec: &str, cfg: &Settings) -> Option<Box<dyn Agent>> {
-        let symbols = if spec.is_empty() {
-            vec!["BTC-USD".to_string()]
-        } else if spec.eq_ignore_ascii_case("all") {
-            match shared_symbols().await {
-                Ok((_, c)) => c,
-                Err(e) => {
-                    tracing::error!(error=%e, "failed to fetch shared symbols");
-                    return None;
-                }
-            }
-        } else {
-            spec.split(',')
-                .map(|s| s.trim().to_uppercase())
-                .filter(|s| !s.is_empty())
-                .collect::<Vec<_>>()
-        };
-        Some(Box::new(CoinbaseAgent::new(symbols, cfg)))
     }
 }
 
@@ -206,7 +170,6 @@ async fn connection_task(
     max_reconnect_delay_secs: u64,
 ) {
     let mut attempt: u32 = 0;
-    let mut last_trade_ids: HashMap<String, i64> = HashMap::new();
 
     loop {
         if *shutdown.borrow() {
@@ -247,7 +210,7 @@ async fn connection_task(
                                         let _ = send_unsubscribe(&mut ws, &to_unsub).await;
                                     }
                                     if !to_sub.is_empty() {
-                                            if let Err(e) = send_subscribe(&mut ws, &to_sub).await {
+                                        if let Err(e) = send_subscribe(&mut ws, &to_sub).await {
                                             tracing::error!(error=%e, "failed to update subscription");
                                             break;
                                         }
@@ -267,206 +230,41 @@ async fn connection_task(
                                 Some(Ok(Message::Text(txt))) => {
                                     if let Ok(v) = serde_json::from_str::<serde_json::Value>(&txt) {
                                         let typ = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
-                                        match typ {
-                                            "match" => {
-                                                let raw = v.get("product_id").and_then(|s| s.as_str()).unwrap_or("?");
-                                                let sym = CanonicalService::canonical_pair("coinbase", raw).unwrap_or_else(|| raw.to_string());
-                                                // Missing or non-positive trade IDs are represented as JSON null.
-                                                let trade_id = v
-                                                    .get("trade_id")
-                                                    .and_then(|id| id.as_i64())
-                                                    .filter(|id| *id > 0);
-                                                let price = v
-                                                    .get("price")
-                                                    .and_then(|p| p.as_str())
-                                                    .and_then(parse_decimal_str)
-                                                    .unwrap_or_else(|| "?".to_string());
-                                                let size = v
-                                                    .get("size")
-                                                    .and_then(|q| q.as_str())
-                                                    .and_then(parse_decimal_str)
-                                                    .unwrap_or_else(|| "?".to_string());
-                                                let ts = v
-                                                    .get("time")
-                                                    .and_then(|t| t.as_str())
-                                                    .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
-                                                    .map(|dt| dt.timestamp_millis())
-                                                    .unwrap_or_default();
-                                                let line = serde_json::json!({
-                                                    "agent": "coinbase",
-                                                    "type": "trade",
-                                                    "s": sym,
-                                                    "t": trade_id,
-                                                    "p": price,
-                                                    "q": size,
-                                                    "ts": ts
-                                                }).to_string();
-                                                if tx.send(line).await.is_err() {
-                                                    let raw = v.get("product_id").and_then(|s| s.as_str()).unwrap_or("?");
-                                                    let sym = CanonicalService::canonical_pair("coinbase", raw)
-                                                        .unwrap_or_else(|| raw.to_string());
-                                                    // Missing or non-positive trade IDs are represented as JSON null.
-                                                    let trade_id = v
-                                                        .get("trade_id")
-                                                        .and_then(|id| id.as_i64())
-                                                        .filter(|id| *id > 0);
-                                                    if let Some(id) = trade_id {
-                                                        if let Some(last) = last_trade_ids.get_mut(&sym) {
-                                                            *last = id;
-                                                        } else {
-                                                            last_trade_ids.insert(sym.clone(), id);
-                                                        }
-                                                    }
-                                                    let price = match v
-                                                        .get("price")
-                                                        .and_then(|p| p.as_str())
-                                                        .and_then(parse_decimal_str)
-                                                    {
-                                                        Some(p) => p,
-                                                        None => {
-                                                            "?".to_string()
-                                                        }
-                                                    };
-                                                    let size = match v
-                                                        .get("size")
-                                                        .and_then(|q| q.as_str())
-                                                        .and_then(parse_decimal_str)
-                                                    {
-                                                        Some(q) => q,
-                                                        None => {
-                                                            "?".to_string()
-                                                        }
-                                                    };
-                                                    let ts = v
-                                                        .get("time")
-                                                        .and_then(|t| t.as_str())
-                                                        .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
-                                                        .map(|dt| dt.timestamp_millis())
-                                                        .unwrap_or_default();
-                                                    let skew = clock::current_skew_ms();
-                                                    let line = serde_json::json!({
-                                                        "agent": "coinbase",
-                                                        "type": "trade",
-                                                        "s": sym,
-                                                        "t": trade_id,
-                                                        "p": price,
-                                                        "q": size,
-                                                        "ts": ts,
-                                                        "skew": skew
-                                                    })
-                                                    .to_string();
-                                                    if tx.send(line).await.is_err() {
-                                                        break;
-                                                    }
-                                                }
-                                            },
-                                            "l2update" => {
-                                                let raw = v.get("product_id").and_then(|s| s.as_str()).unwrap_or("?");
-                                                let sym = CanonicalService::canonical_pair("coinbase", raw).unwrap_or_else(|| raw.to_string());
-                                                let mut bids = Vec::new();
-                                                let mut asks = Vec::new();
-                                                if let Some(changes) = v.get("changes").and_then(|c| c.as_array()) {
-                                                    for c in changes {
-                                                        if let (Some(side), Some(p), Some(sz)) = (
-                                                            c.get(0).and_then(|s| s.as_str()),
-                                                            c.get(1).and_then(|p| p.as_str()),
-                                                            c.get(2).and_then(|q| q.as_str()),
-                                                        ) {
-                                                            let price = parse_decimal_str(p);
-                                                            let qty = parse_decimal_str(sz);
-                                                            if let (Some(price), Some(qty)) = (price, qty) {
-                                                                if side == "buy" {
-                                                                    bids.push([price, qty]);
-                                                                } else {
-                                                                    asks.push([price, qty]);
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                                let ts = v
-                                                    .get("time")
-                                                    .and_then(|t| t.as_str())
-                                                    .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
-                                                    .map(|dt| dt.timestamp_millis())
-                                                    .unwrap_or_default();
-                                                let line = serde_json::json!({
-                                                    "agent": "coinbase",
-                                                    "type": "l2_diff",
-                                                    "s": sym,
-                                                    "bids": bids,
-                                                    "asks": asks,
-                                                    "ts": ts
-                                                }).to_string();
-                                                if tx.send(line).await.is_ok() {
-                                                } else { break; }
+                                        if typ == "match" {
+                                            let raw = v.get("product_id").and_then(|s| s.as_str()).unwrap_or("?");
+                                            let sym = CanonicalService::canonical_pair("coinbase", raw).unwrap_or_else(|| raw.to_string());
+                                            let trade_id = v
+                                                .get("trade_id")
+                                                .and_then(|id| id.as_i64())
+                                                .filter(|id| *id > 0);
+                                            let price = v
+                                                .get("price")
+                                                .and_then(|p| p.as_str())
+                                                .and_then(parse_decimal_str)
+                                                .unwrap_or_else(|| "?".to_string());
+                                            let size = v
+                                                .get("size")
+                                                .and_then(|q| q.as_str())
+                                                .and_then(parse_decimal_str)
+                                                .unwrap_or_else(|| "?".to_string());
+                                            let ts = v
+                                                .get("time")
+                                                .and_then(|t| t.as_str())
+                                                .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
+                                                .map(|dt| dt.timestamp_millis())
+                                                .unwrap_or_default();
+                                            let line = serde_json::json!({
+                                                "agent": "coinbase",
+                                                "type": "trade",
+                                                "s": sym,
+                                                "t": trade_id,
+                                                "p": price,
+                                                "q": size,
+                                                "ts": ts
+                                            }).to_string();
+                                            if tx.send(line).await.is_err() {
+                                                break;
                                             }
-                                            "snapshot" => {
-                                                let raw = v.get("product_id").and_then(|s| s.as_str()).unwrap_or("?");
-                                                let sym = CanonicalService::canonical_pair("coinbase", raw).unwrap_or_else(|| raw.to_string());
-                                                let bids = v
-                                                    .get("bids")
-                                                    .and_then(|b| b.as_array())
-                                                    .cloned()
-                                                    .unwrap_or_default()
-                                                    .into_iter()
-                                                    .filter_map(|lvl| {
-                                                        let p = lvl.get(0)?.as_str()?.to_string();
-                                                        let q = lvl.get(1)?.as_str()?.to_string();
-                                                        Some([p, q])
-                                                    })
-                                                    .collect::<Vec<[String;2]>>();
-                                                let asks = v
-                                                    .get("asks")
-                                                    .and_then(|a| a.as_array())
-                                                    .cloned()
-                                                    .unwrap_or_default()
-                                                    .into_iter()
-                                                    .filter_map(|lvl| {
-                                                        let p = lvl.get(0)?.as_str()?.to_string();
-                                                        let q = lvl.get(1)?.as_str()?.to_string();
-                                                        Some([p, q])
-                                                    })
-                                                    .collect::<Vec<[String;2]>>();
-                                                let ts = chrono::Utc::now().timestamp_millis();
-                                                let line = serde_json::json!({
-                                                    "agent": "coinbase",
-                                                    "type": "snapshot",
-                                                    "s": sym,
-                                                    "bids": bids,
-                                                    "asks": asks,
-                                                    "ts": ts
-                                                }).to_string();
-                                                if tx.send(line).await.is_ok() {
-                                                } else { break; }
-                                            }
-                                            "ticker" => {
-                                                let raw = v.get("product_id").and_then(|s| s.as_str()).unwrap_or("?");
-                                                let sym = CanonicalService::canonical_pair("coinbase", raw).unwrap_or_else(|| raw.to_string());
-                                                let bid_px = v.get("best_bid").and_then(|p| p.as_str()).and_then(parse_decimal_str).unwrap_or_else(|| "?".to_string());
-                                                let bid_qty = v.get("best_bid_size").and_then(|q| q.as_str()).and_then(parse_decimal_str).unwrap_or_else(|| "?".to_string());
-                                                let ask_px = v.get("best_ask").and_then(|p| p.as_str()).and_then(parse_decimal_str).unwrap_or_else(|| "?".to_string());
-                                                let ask_qty = v.get("best_ask_size").and_then(|q| q.as_str()).and_then(parse_decimal_str).unwrap_or_else(|| "?".to_string());
-                                                let ts = v
-                                                    .get("time")
-                                                    .and_then(|t| t.as_str())
-                                                    .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
-                                                    .map(|dt| dt.timestamp_millis())
-                                                    .unwrap_or_default();
-                                                let line = serde_json::json!({
-                                                    "agent": "coinbase",
-                                                    "type": "book_ticker",
-                                                    "s": sym,
-                                                    "bp": bid_px,
-                                                    "bq": bid_qty,
-                                                    "ap": ask_px,
-                                                    "aq": ask_qty,
-                                                    "ts": ts
-                                                }).to_string();
-                                                if tx.send(line).await.is_ok() {
-                                                } else { break; }
-                                            }
-                                            _ => {}
                                         }
                                     } else {
                                         tracing::warn!("non-json text msg");
@@ -474,7 +272,7 @@ async fn connection_task(
                                 }
                                 Some(Ok(Message::Ping(p))) => { let _ = ws.send(Message::Pong(p)).await; }
                                 Some(Ok(Message::Close(frame))) => { tracing::warn!(?frame, "server closed connection"); break; }
-                                Some(Ok(_)) => { }
+                                Some(Ok(_)) => {}
                                 Some(Err(e)) => { tracing::error!(error=%e, "ws error"); break; }
                                 None => { tracing::warn!("stream ended"); break; }
                             }
@@ -509,6 +307,31 @@ async fn connection_task(
     }
 }
 
+pub struct CoinbaseFactory;
+
+#[async_trait::async_trait]
+impl AgentFactory for CoinbaseFactory {
+    async fn create(&self, spec: &str, cfg: &Settings) -> Option<Box<dyn Agent>> {
+        let symbols = if spec.is_empty() {
+            vec!["BTC-USD".to_string()]
+        } else if spec.eq_ignore_ascii_case("all") {
+            match shared_symbols().await {
+                Ok((_, c)) => c,
+                Err(e) => {
+                    tracing::error!(error=%e, "failed to fetch shared symbols");
+                    return None;
+                }
+            }
+        } else {
+            spec.split(',')
+                .map(|s| s.trim().to_uppercase())
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+        };
+        Some(Box::new(CoinbaseAgent::new(symbols, cfg)))
+    }
+}
+
 async fn send_subscribe(
     ws: &mut WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>,
     symbols: &[String],
@@ -516,7 +339,7 @@ async fn send_subscribe(
     let msg = serde_json::json!({
         "type": "subscribe",
         "product_ids": symbols,
-        "channels": ["matches", "level2", "ticker"],
+        "channels": ["matches"],
     });
     ws.send(Message::Text(msg.to_string())).await
 }
@@ -531,74 +354,7 @@ async fn send_unsubscribe(
     let msg = serde_json::json!({
         "type": "unsubscribe",
         "product_ids": symbols,
-        "channels": ["matches", "level2", "ticker"],
+        "channels": ["matches"],
     });
     ws.send(Message::Text(msg.to_string())).await
-}
-
-async fn snapshot_task(symbol: String, tx: mpsc::Sender<String>) {
-    let client = match http_client::builder().build() {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::error!(error=%e, "coinbase snapshot http client");
-            return;
-        }
-    };
-    let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
-    loop {
-        let url = format!(
-            "https://api.exchange.coinbase.com/products/{}/book?level=2",
-            symbol
-        );
-        match client.get(&url).send().await {
-            Ok(resp) => match resp.json::<serde_json::Value>().await {
-                Ok(v) => {
-                    let bids = v
-                        .get("bids")
-                        .and_then(|b| b.as_array())
-                        .cloned()
-                        .unwrap_or_default()
-                        .into_iter()
-                        .filter_map(|lvl| {
-                            let p = lvl.get(0)?.as_str()?.to_string();
-                            let q = lvl.get(1)?.as_str()?.to_string();
-                            Some([p, q])
-                        })
-                        .collect::<Vec<[String; 2]>>();
-                    let asks = v
-                        .get("asks")
-                        .and_then(|a| a.as_array())
-                        .cloned()
-                        .unwrap_or_default()
-                        .into_iter()
-                        .filter_map(|lvl| {
-                            let p = lvl.get(0)?.as_str()?.to_string();
-                            let q = lvl.get(1)?.as_str()?.to_string();
-                            Some([p, q])
-                        })
-                        .collect::<Vec<[String; 2]>>();
-                    let sym = CanonicalService::canonical_pair("coinbase", &symbol)
-                        .unwrap_or_else(|| symbol.clone());
-                    let ts = chrono::Utc::now().timestamp_millis();
-                    let line = serde_json::json!({
-                        "agent": "coinbase",
-                        "type": "snapshot",
-                        "s": sym,
-                        "bids": bids,
-                        "asks": asks,
-                        "ts": ts
-                    })
-                    .to_string();
-                    let _ = tx.send(line).await;
-                }
-                Err(e) => {
-                    tracing::error!(error=%e, symbol=%symbol, "snapshot parse failed");
-                }
-            },
-            Err(e) => {
-                tracing::error!(error=%e, symbol=%symbol, "snapshot failed");
-            }
-        }
-        interval.tick().await;
-    }
 }

--- a/crypto-ingestor/src/config.rs
+++ b/crypto-ingestor/src/config.rs
@@ -24,54 +24,6 @@ pub struct Cli {
     #[arg(long)]
     pub trades: bool,
 
-    /// Enable level 2 diff order book feeds
-    #[arg(long)]
-    pub l2_diffs: bool,
-
-    /// Enable level 2 snapshot order book feeds
-    #[arg(long)]
-    pub l2_snapshots: bool,
-
-    /// Enable book ticker updates
-    #[arg(long)]
-    pub book_ticker: bool,
-
-    /// Enable rolling 24h ticker updates
-    #[arg(long)]
-    pub ticker_24h: bool,
-
-    /// Enable OHLCV candle data
-    #[arg(long)]
-    pub ohlcv: bool,
-
-    /// Enable index price feeds
-    #[arg(long)]
-    pub index_price: bool,
-
-    /// Enable mark price feeds
-    #[arg(long)]
-    pub mark_price: bool,
-
-    /// Enable funding rates
-    #[arg(long)]
-    pub funding_rates: bool,
-
-    /// Enable open interest data
-    #[arg(long)]
-    pub open_interest: bool,
-
-    /// Enable top DEX pool price feeds
-    #[arg(long)]
-    pub top_dex_pools: bool,
-
-    /// Enable news headline feeds
-    #[arg(long)]
-    pub news_headlines: bool,
-
-    /// Enable telemetry events
-    #[arg(long)]
-    pub telemetry: bool,
-
     /// Agent specifications (e.g. binance:btcusdt)
     pub specs: Vec<String>,
 }
@@ -118,30 +70,6 @@ pub struct Settings {
 
     #[serde(default)]
     pub trades: bool,
-    #[serde(default)]
-    pub l2_diffs: bool,
-    #[serde(default)]
-    pub l2_snapshots: bool,
-    #[serde(default)]
-    pub book_ticker: bool,
-    #[serde(default)]
-    pub ticker_24h: bool,
-    #[serde(default)]
-    pub ohlcv: bool,
-    #[serde(default)]
-    pub index_price: bool,
-    #[serde(default)]
-    pub mark_price: bool,
-    #[serde(default)]
-    pub funding_rates: bool,
-    #[serde(default)]
-    pub open_interest: bool,
-    #[serde(default)]
-    pub top_dex_pools: bool,
-    #[serde(default)]
-    pub news_headlines: bool,
-    #[serde(default)]
-    pub telemetry: bool,
 }
 
 fn default_sink() -> String {
@@ -185,18 +113,6 @@ impl Default for Settings {
             sink: default_sink(),
             file_path: None,
             trades: false,
-            l2_diffs: false,
-            l2_snapshots: false,
-            book_ticker: false,
-            ticker_24h: false,
-            ohlcv: false,
-            index_price: false,
-            mark_price: false,
-            funding_rates: false,
-            open_interest: false,
-            top_dex_pools: false,
-            news_headlines: false,
-            telemetry: false,
         }
     }
 }
@@ -226,18 +142,6 @@ impl Settings {
             .set_default("coinbase_ohlcv_intervals", vec![60])?
             .set_default("sink", "stdout")?
             .set_default("trades", false)?
-            .set_default("l2_diffs", false)?
-            .set_default("l2_snapshots", false)?
-            .set_default("book_ticker", false)?
-            .set_default("ticker_24h", false)?
-            .set_default("ohlcv", false)?
-            .set_default("index_price", false)?
-            .set_default("mark_price", false)?
-            .set_default("funding_rates", false)?
-            .set_default("open_interest", false)?
-            .set_default("top_dex_pools", false)?
-            .set_default("news_headlines", false)?
-            .set_default("telemetry", false)?
             .add_source(config::Environment::with_prefix("INGESTOR").separator("_"));
         if let Some(path) = &cli.config {
             builder = builder.add_source(config::File::with_name(path));
@@ -263,18 +167,6 @@ impl Settings {
             .coinbase_api_secret
             .or_else(|| std::env::var("COINBASE_API_SECRET").ok());
         settings.trades = settings.trades || cli.trades;
-        settings.l2_diffs = settings.l2_diffs || cli.l2_diffs;
-        settings.l2_snapshots = settings.l2_snapshots || cli.l2_snapshots;
-        settings.book_ticker = settings.book_ticker || cli.book_ticker;
-        settings.ticker_24h = settings.ticker_24h || cli.ticker_24h;
-        settings.ohlcv = settings.ohlcv || cli.ohlcv;
-        settings.index_price = settings.index_price || cli.index_price;
-        settings.mark_price = settings.mark_price || cli.mark_price;
-        settings.funding_rates = settings.funding_rates || cli.funding_rates;
-        settings.open_interest = settings.open_interest || cli.open_interest;
-        settings.top_dex_pools = settings.top_dex_pools || cli.top_dex_pools;
-        settings.news_headlines = settings.news_headlines || cli.news_headlines;
-        settings.telemetry = settings.telemetry || cli.telemetry;
         settings.binance_futures_rest_url =
             settings.binance_futures_rest_url.filter(|s| !s.is_empty());
         settings.binance_futures_ws_url = settings.binance_futures_ws_url.filter(|s| !s.is_empty());


### PR DESCRIPTION
## Summary
- drop CLI flags and config fields for non-trade feeds
- simplify Binance and Coinbase agents to stream trades only
- update README to mention trades feed only

## Testing
- `cargo test` *(hangs on websocket test: binance_trade_messages_are_canonicalized_with_id)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a00bd3788323b17ed986a8d0b2ab