### PR TITLE
Remove Binance futures tasks and config fields

### DIFF
--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -8,11 +8,7 @@ use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, Web
 
 use crate::clock;
 use crate::{
-    agent::Agent,
-    config::Settings,
-    error::IngestorError,
-    http_client,
-    parse::parse_decimal_str,
+    agent::Agent, config::Settings, error::IngestorError, http_client, parse::parse_decimal_str,
 };
 
 use super::{shared_symbols, AgentFactory};
@@ -75,9 +71,6 @@ pub struct BinanceAgent {
     ws_url: String,
     max_reconnect_delay_secs: u64,
     refresh_interval_mins: u64,
-    futures_ws_url: Option<String>,
-    futures_rest_url: Option<String>,
-    open_interest: bool,
 }
 
 impl BinanceAgent {
@@ -92,9 +85,6 @@ impl BinanceAgent {
             ws_url: cfg.binance_ws_url.clone(),
             max_reconnect_delay_secs: cfg.binance_max_reconnect_delay_secs,
             refresh_interval_mins: cfg.binance_refresh_interval_mins,
-            futures_ws_url: cfg.binance_futures_ws_url.clone(),
-            futures_rest_url: cfg.binance_futures_rest_url.clone(),
-            open_interest: cfg.open_interest,
         })
     }
 }
@@ -131,48 +121,6 @@ impl Agent for BinanceAgent {
             let tx_clone = out_tx.clone();
             handles.push(tokio::spawn(async move {
                 connection_task(rx, shutdown_rx, tx_clone, ws_url, max_delay).await;
-            }));
-        }
-        // additional aggregated streams not tied to symbol subsets
-        if let Some(ws_url) = &self.futures_ws_url {
-            let shutdown_clone = shutdown.clone();
-            let tx_clone = out_tx.clone();
-            let url = ws_url.clone();
-            handles.push(tokio::spawn(async move {
-                mark_price_task(&url, shutdown_clone, tx_clone).await;
-            }));
-
-            let shutdown_clone = shutdown.clone();
-            let tx_clone = out_tx.clone();
-            let url = ws_url.clone();
-            handles.push(tokio::spawn(async move {
-                funding_rate_task(&url, shutdown_clone, tx_clone).await;
-            }));
-
-            if self.open_interest {
-                let shutdown_clone = shutdown.clone();
-                let tx_clone = out_tx.clone();
-                let url = ws_url.clone();
-                handles.push(tokio::spawn(async move {
-                    open_interest_task(&url, shutdown_clone, tx_clone).await;
-                }));
-            }
-
-            let shutdown_clone = shutdown.clone();
-            let tx_clone = out_tx.clone();
-            let url = ws_url.clone();
-            handles.push(tokio::spawn(async move {
-                liquidation_task(&url, shutdown_clone, tx_clone).await;
-            }));
-        }
-
-        if let Some(rest_url) = &self.futures_rest_url {
-            let symbols_clone = self.symbols.clone();
-            let shutdown_clone = shutdown.clone();
-            let tx_clone = out_tx.clone();
-            let url = rest_url.clone();
-            handles.push(tokio::spawn(async move {
-                term_structure_task(symbols_clone, &url, shutdown_clone, tx_clone).await;
             }));
         }
         for sym in self.symbols.clone() {
@@ -643,249 +591,4 @@ async fn send_unsubscribe(
         "id": 1,
     });
     ws.send(Message::Text(msg.to_string())).await
-}
-
-async fn mark_price_task(
-    base_ws_url: &str,
-    shutdown: tokio::sync::watch::Receiver<bool>,
-    tx: mpsc::Sender<String>,
-) {
-    let url = format!("{}/stream?streams=!markPrice@arr", base_ws_url);
-    aggregated_ws_loop(&url, "mark_price", shutdown, tx, |item| {
-        let raw = item.get("s").and_then(|s| s.as_str()).unwrap_or("?");
-        let sym =
-            CanonicalService::canonical_pair("binance", raw).unwrap_or_else(|| raw.to_string());
-        let price = item
-            .get("p")
-            .and_then(|p| p.as_str())
-            .and_then(parse_decimal_str)
-            .unwrap_or_else(|| "?".to_string());
-        let ts = item.get("E").and_then(|x| x.as_i64()).unwrap_or_default();
-        let line = serde_json::json!({
-            "agent": "binance",
-            "type": "mark_price",
-            "s": sym,
-            "p": price,
-            "ts": ts
-        })
-        .to_string();
-        (line, ts)
-    })
-    .await;
-}
-
-async fn funding_rate_task(
-    base_ws_url: &str,
-    shutdown: tokio::sync::watch::Receiver<bool>,
-    tx: mpsc::Sender<String>,
-) {
-    let url = format!("{}/stream?streams=!fundingRate@arr", base_ws_url);
-    aggregated_ws_loop(&url, "funding", shutdown, tx, |item| {
-        let raw = item.get("s").and_then(|s| s.as_str()).unwrap_or("?");
-        let sym =
-            CanonicalService::canonical_pair("binance", raw).unwrap_or_else(|| raw.to_string());
-        let rate = item
-            .get("r")
-            .and_then(|p| p.as_str())
-            .and_then(parse_decimal_str)
-            .unwrap_or_else(|| "?".to_string());
-        let ts = item.get("T").and_then(|x| x.as_i64()).unwrap_or_default();
-        let line = serde_json::json!({
-            "agent": "binance",
-            "type": "funding",
-            "s": sym,
-            "r": rate,
-            "ts": ts
-        })
-        .to_string();
-        (line, ts)
-    })
-    .await;
-}
-
-async fn open_interest_task(
-    base_ws_url: &str,
-    shutdown: tokio::sync::watch::Receiver<bool>,
-    tx: mpsc::Sender<String>,
-) {
-    let url = format!("{}/stream?streams=!openInterest@arr", base_ws_url);
-    aggregated_ws_loop(&url, "open_interest", shutdown, tx, |item| {
-        let raw = item.get("s").and_then(|s| s.as_str()).unwrap_or("?");
-        let sym =
-            CanonicalService::canonical_pair("binance", raw).unwrap_or_else(|| raw.to_string());
-        let oi = item
-            .get("oi")
-            .and_then(|p| p.as_str())
-            .and_then(parse_decimal_str)
-            .unwrap_or_else(|| "?".to_string());
-        let ts = item.get("T").and_then(|x| x.as_i64()).unwrap_or_default();
-        let line = serde_json::json!({
-            "agent": "binance",
-            "type": "open_interest",
-            "s": sym,
-            "oi": oi,
-            "ts": ts
-        })
-        .to_string();
-        (line, ts)
-    })
-    .await;
-}
-
-async fn liquidation_task(
-    base_ws_url: &str,
-    shutdown: tokio::sync::watch::Receiver<bool>,
-    tx: mpsc::Sender<String>,
-) {
-    let url = format!("{}/stream?streams=!forceOrder@arr", base_ws_url);
-    aggregated_ws_loop(&url, "liquidation", shutdown, tx, |item| {
-        let raw = item.get("s").and_then(|s| s.as_str()).unwrap_or("?");
-        let sym =
-            CanonicalService::canonical_pair("binance", raw).unwrap_or_else(|| raw.to_string());
-        let o = item.get("o").and_then(|o| o.as_object());
-        let price = o
-            .and_then(|m| m.get("p"))
-            .and_then(|p| p.as_str())
-            .and_then(parse_decimal_str)
-            .unwrap_or_else(|| "?".to_string());
-        let qty = o
-            .and_then(|m| m.get("q"))
-            .and_then(|p| p.as_str())
-            .and_then(parse_decimal_str)
-            .unwrap_or_else(|| "?".to_string());
-        let side = o
-            .and_then(|m| m.get("S"))
-            .and_then(|s| s.as_str())
-            .unwrap_or("?")
-            .to_string();
-        let ts = item.get("E").and_then(|x| x.as_i64()).unwrap_or_default();
-        let line = serde_json::json!({
-            "agent": "binance",
-            "type": "liquidation",
-            "s": sym,
-            "p": price,
-            "q": qty,
-            "side": side,
-            "ts": ts
-        })
-        .to_string();
-        (line, ts)
-    })
-    .await;
-}
-
-async fn term_structure_task(
-    symbols: Vec<String>,
-    rest_url: &str,
-    mut shutdown: tokio::sync::watch::Receiver<bool>,
-    tx: mpsc::Sender<String>,
-) {
-    let client = match http_client::builder().build() {
-        Ok(c) => c,
-        Err(_) => return,
-    };
-    let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
-    loop {
-        tokio::select! {
-            _ = shutdown.changed() => {
-                if *shutdown.borrow() { break; }
-            }
-            _ = interval.tick() => {
-                for sym in &symbols {
-                    let url = format!("{}/futures/data/basis?symbol={}&period=5m&limit=1", rest_url, sym.to_uppercase());
-                    if let Ok(resp) = client.get(&url).send().await {
-                        if let Ok(resp) = resp.json::<serde_json::Value>().await {
-                            if let Some(arr) = resp.as_array().and_then(|a| a.first()) {
-                                let raw = arr.get("symbol").and_then(|s| s.as_str()).unwrap_or("?");
-                                let canon = CanonicalService::canonical_pair("binance", raw).unwrap_or_else(|| raw.to_string());
-                                let basis = arr
-                                    .get("basis")
-                                    .and_then(|b| b.as_str())
-                                    .and_then(parse_decimal_str)
-                                    .unwrap_or_else(|| "?".to_string());
-                                let ts = arr.get("timestamp").and_then(|t| t.as_i64()).unwrap_or_default();
-                                let line = serde_json::json!({
-                                    "agent": "binance",
-                                    "type": "term",
-                                    "s": canon,
-                                    "b": basis,
-                                    "ts": ts
-                                }).to_string();
-                                let _ = tx.send(line).await;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-async fn aggregated_ws_loop<F>(
-    url: &str,
-    _metric: &str,
-    mut shutdown: tokio::sync::watch::Receiver<bool>,
-    tx: mpsc::Sender<String>,
-    mut build: F,
-) where
-    F: FnMut(&serde_json::Value) -> (String, i64),
-{
-    let mut attempt: u32 = 0;
-    loop {
-        if *shutdown.borrow() {
-            break;
-        }
-        tracing::info!(%url, "connecting");
-        match connect_async(url).await {
-            Ok((mut ws, _)) => {
-                attempt = 0;
-                loop {
-                    tokio::select! {
-                        _ = shutdown.changed() => {
-                            if *shutdown.borrow() {
-                                let _ = ws.close(None).await;
-                                return;
-                            }
-                        }
-                        msg = ws.next() => {
-                            match msg {
-                                Some(Ok(Message::Text(txt))) => {
-                                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&txt) {
-                                        if let Some(arr) = v.get("data").and_then(|d| d.as_array()) {
-                                            for item in arr {
-                                                let (line, _ts) = build(item);
-                                                let _ = tx.send(line).await;
-                                            }
-                                        }
-                                    }
-                                },
-                                Some(Ok(Message::Ping(p))) => { let _ = ws.send(Message::Pong(p)).await; }
-                                Some(Ok(Message::Close(_))) => { break; }
-                                Some(Ok(_)) => {}
-                                Some(Err(e)) => { tracing::error!(error=%e, "ws error"); break; }
-                                None => { break; }
-                            }
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                tracing::error!(error=%e, "connect failed");
-            }
-        }
-
-        attempt = attempt.saturating_add(1);
-        let exp: u32 = attempt.saturating_sub(1).min(4);
-        let delay = (1u64 << exp).min(16);
-        let sleep = std::time::Duration::from_secs(delay);
-        tracing::info!(?sleep, "reconnecting");
-        tokio::select! {
-            _ = tokio::time::sleep(sleep) => {},
-            _ = shutdown.changed() => {
-                if *shutdown.borrow() {
-                    break;
-                }
-            }
-        }
-    }
 }

--- a/crypto-ingestor/src/config.rs
+++ b/crypto-ingestor/src/config.rs
@@ -83,10 +83,6 @@ pub struct Settings {
     pub binance_refresh_interval_mins: u64,
     pub binance_max_reconnect_delay_secs: u64,
     #[serde(default)]
-    pub binance_futures_rest_url: Option<String>,
-    #[serde(default)]
-    pub binance_futures_ws_url: Option<String>,
-    #[serde(default)]
     pub binance_options_rest_url: String,
     #[serde(default)]
     pub binance_options_symbols: Vec<String>,
@@ -135,8 +131,6 @@ pub struct Settings {
     #[serde(default)]
     pub funding_rates: bool,
     #[serde(default)]
-    pub open_interest: bool,
-    #[serde(default)]
     pub top_dex_pools: bool,
     #[serde(default)]
     pub news_headlines: bool,
@@ -166,8 +160,6 @@ impl Default for Settings {
             binance_ws_url: String::new(),
             binance_refresh_interval_mins: 60,
             binance_max_reconnect_delay_secs: 30,
-            binance_futures_rest_url: None,
-            binance_futures_ws_url: None,
             binance_options_rest_url: String::new(),
             binance_options_symbols: Vec::new(),
             binance_options_poll_interval_secs: 60,
@@ -193,7 +185,6 @@ impl Default for Settings {
             index_price: false,
             mark_price: false,
             funding_rates: false,
-            open_interest: false,
             top_dex_pools: false,
             news_headlines: false,
             telemetry: false,
@@ -207,8 +198,6 @@ impl Settings {
             .set_default("binance_ws_url", "wss://stream.binance.us:9443/ws")?
             .set_default("binance_refresh_interval_mins", 60)?
             .set_default("binance_max_reconnect_delay_secs", 30)?
-            .set_default("binance_futures_rest_url", "https://fapi.binance.com")?
-            .set_default("binance_futures_ws_url", "wss://fstream.binance.com")?
             .set_default(
                 "binance_options_rest_url",
                 "https://eapi.binance.us/eapi/v1",
@@ -234,7 +223,6 @@ impl Settings {
             .set_default("index_price", false)?
             .set_default("mark_price", false)?
             .set_default("funding_rates", false)?
-            .set_default("open_interest", false)?
             .set_default("top_dex_pools", false)?
             .set_default("news_headlines", false)?
             .set_default("telemetry", false)?
@@ -271,13 +259,9 @@ impl Settings {
         settings.index_price = settings.index_price || cli.index_price;
         settings.mark_price = settings.mark_price || cli.mark_price;
         settings.funding_rates = settings.funding_rates || cli.funding_rates;
-        settings.open_interest = settings.open_interest || cli.open_interest;
         settings.top_dex_pools = settings.top_dex_pools || cli.top_dex_pools;
         settings.news_headlines = settings.news_headlines || cli.news_headlines;
         settings.telemetry = settings.telemetry || cli.telemetry;
-        settings.binance_futures_rest_url =
-            settings.binance_futures_rest_url.filter(|s| !s.is_empty());
-        settings.binance_futures_ws_url = settings.binance_futures_ws_url.filter(|s| !s.is_empty());
         Ok(settings)
     }
 }


### PR DESCRIPTION
## Summary
- drop Binance futures WebSocket/REST URLs and open interest flag from settings
- strip Binance agent of futures-specific fields and aggregated tasks

## Testing
- `cargo check`
- `cargo test` *(fails: process hung and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a00dea50832381681d513ac8cf7b