### PR TITLE
Remove insecure TLS settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Simple cryptocurrency data ingestor demonstrating async Rust agents. Both
 Binance and Coinbase agents stream market data via WebSockets.
 
-> **Note:** Development builds disable TLS certificate verification; do not use in production.
+> **Note:** TLS certificate verification is enforced in all builds by default.
 
 This repository is organised as a Cargo workspace containing several crates:
 

--- a/canonicalizer/src/http_client.rs
+++ b/canonicalizer/src/http_client.rs
@@ -2,9 +2,8 @@ use reqwest::ClientBuilder;
 
 /// Build a `reqwest::ClientBuilder` configured for this crate.
 ///
-/// Certificate verification is disabled to allow operation against hosts with
-/// self-signed or otherwise untrusted certificates. **This should not be used
-/// in production.**
+/// The builder uses reqwest's default TLS settings which enforce certificate
+/// verification.
 pub fn builder() -> ClientBuilder {
-    reqwest::Client::builder().danger_accept_invalid_certs(true)
+    reqwest::Client::builder()
 }

--- a/crypto-ingestor/src/http_client.rs
+++ b/crypto-ingestor/src/http_client.rs
@@ -3,9 +3,8 @@ use reqwest::ClientBuilder;
 
 /// Build a `reqwest::ClientBuilder` configured for the current runtime.
 ///
-/// Certificate verification is disabled in this environment to allow
-/// connections to hosts with self-signed or otherwise untrusted certificates.
-/// **Do not enable this behaviour in production.**
+/// The returned builder uses reqwest's default TLS settings which enforce
+/// certificate verification.
 pub fn builder() -> ClientBuilder {
-    reqwest::Client::builder().danger_accept_invalid_certs(true)
+    reqwest::Client::builder()
 }

--- a/docs/CRATE_MAP.md
+++ b/docs/CRATE_MAP.md
@@ -36,7 +36,7 @@ clap 4, config 0.13, rust_decimal 1, thiserror 1.
 *Modules*:
 - `lib` – `CanonicalService` and event types (`L2Diff`, etc.).
 - `events` – additional canonical structs (`Bar`, `Order`, ...).
-- `http_client` – helper to build TLS HTTP client.
+- `http_client` – helper to build TLS HTTP client with certificate verification.
 
 *Normalization implementations*: `CanonicalService::canonical_pair`.
 


### PR DESCRIPTION
## Summary
- build HTTP clients with secure defaults (no invalid cert acceptance)
- update documentation to state TLS verification is enforced

## Testing
- `cargo check`
- `cargo test` *(fails: binance_trade_messages_are_canonicalized_with_id and coinbase_trade_messages_are_canonicalized_with_id running over 60 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a01364248323bc2c82021ebc6d6e