### PR TITLE
fix(binance): remove merge artifact in trade JSON

### DIFF
--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -378,34 +378,27 @@ async fn connection_task(
                                                         last_trade_ids.insert(sym.clone(), id);
                                                     }
                                                 }
-                                                let px = v
-                                                    .get("p")
-                                                    .and_then(|p| p.as_str())
-                                                    .and_then(parse_decimal_str)
-                                                    .unwrap_or_else(|| "?".to_string());
-                                                let qty = v
-                                                    .get("q")
-                                                    .and_then(|q| q.as_str())
-                                                    .and_then(parse_decimal_str)
-                                                    .unwrap_or_else(|| "?".to_string());
-                                                let ts = v.get("T").and_then(|x| x.as_i64()).unwrap_or_default();
-                                                let skew = clock::current_skew_ms();
-                                                {
-                                                    Some(q) => q,
-                                                    None => {                                                        "?".to_string()
-                                                    }
-                                                };
-                                                  let ts = v.get("T").and_then(|x| x.as_i64()).unwrap_or_default();
-                                                let line = serde_json::json!({
-                                                    "agent": "binance",
-                                                    "type": "trade",
-                                                    "s": sym,
-                                                    "t": trade_id,
-                                                    "p": px,
-                                                    "q": qty,
-                                                    "ts": ts
-                                                })<<<<<<< codex/remove-binanceagent-futures-fields-and-tasks
-                                                .to_string();
+                                               let px = v
+                                                   .get("p")
+                                                   .and_then(|p| p.as_str())
+                                                   .and_then(parse_decimal_str)
+                                                   .unwrap_or_else(|| "?".to_string());
+                                               let qty = v
+                                                   .get("q")
+                                                   .and_then(|q| q.as_str())
+                                                   .and_then(parse_decimal_str)
+                                                   .unwrap_or_else(|| "?".to_string());
+                                               let ts = v.get("T").and_then(|x| x.as_i64()).unwrap_or_default();
+                                               let line = serde_json::json!({
+                                                   "agent": "binance",
+                                                   "type": "trade",
+                                                   "s": sym,
+                                                   "t": trade_id,
+                                                   "p": px,
+                                                   "q": qty,
+                                                   "ts": ts
+                                               })
+                                               .to_string();
                                                 if tx.send(line).await.is_err() {
                                                     break;
                                                 }


### PR DESCRIPTION
## Summary
- clean up Binance trade JSON builder by removing merge conflict marker

## Testing
- `cargo test` *(fails: file not found for module `metadata` and unclosed delimiter in `coinbase` module)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a8b5cf54832393fe33a9df089377