### PR TITLE
Remove obsolete agent module declarations

### DIFF
--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -1,7 +1,4 @@
 use futures_util::{SinkExt, StreamExt};
-pub mod metadata;
-pub mod ohlcv;
-pub mod options;
 use std::collections::{HashMap, HashSet};
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};

--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -1,8 +1,5 @@
 use futures_util::{SinkExt, StreamExt};
-pub mod metadata;
 use std::collections::{HashMap, HashSet};
-pub mod ohlcv;
-use std::collections::HashSet;
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
 


### PR DESCRIPTION
## Summary
- remove unused module declarations from Binance and Coinbase agents to match file layout

## Testing
- `cargo test` *(fails: file contains an unclosed delimiter in crypto-ingestor/src/agents/coinbase/mod.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a7f3233c8323bfae1425f05133ab