### PR TITLE
refactor: tidy coinbase imports

### DIFF
--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -1,16 +1,18 @@
-use futures_util::{SinkExt, StreamExt};
 pub mod metadata;
-use std::collections::{HashMap, HashSet};
 pub mod ohlcv;
+
 use std::collections::HashSet;
+
+use futures_util::{SinkExt, StreamExt};
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
+use canonicalizer::CanonicalService;
 
-use super::{shared_symbols, AgentFactory};
 use crate::{
     agent::Agent, config::Settings, error::IngestorError, http_client, parse::parse_decimal_str,
 };
-use canonicalizer::CanonicalService;
+
+use super::{shared_symbols, AgentFactory};
 
 /// Fetch all tradable USD product IDs from Coinbase.
 pub async fn fetch_all_symbols() -> Result<Vec<String>, IngestorError> {


### PR DESCRIPTION
## Summary
- dedupe HashSet imports in Coinbase agent
- group standard, external, and internal imports

## Testing
- `cargo test -p ingestor` (fails: file not found for module `metadata`, `ohlcv`, `options`; unclosed delimiter in coinbase file)

------
https://chatgpt.com/codex/tasks/task_e_68b4a7f2d1b48323b84ba50b2a0d5c90