### PR TITLE
Remove stray merge marker in config default_sink

### DIFF
--- a/crypto-ingestor/src/config.rs
+++ b/crypto-ingestor/src/config.rs
@@ -79,7 +79,6 @@ pub struct Settings {
 
 fn default_sink() -> String {
     "stdout".into()
-=======
 }
 
 fn default_binance_options_poll_interval_secs() -> u64 {


### PR DESCRIPTION
## Summary
- Clean up merge artifact in `default_sink` of `config.rs`
- Run rustfmt on the file

## Testing
- `cargo check -p ingestor` *(fails: file not found for module `metadata`; unclosed delimiter in coinbase mod)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a7f0a6c08323bbff7439ba90e11c