### PR TITLE
chore: remove unused default_sink

### DIFF
--- a/crypto-ingestor/src/config.rs
+++ b/crypto-ingestor/src/config.rs
@@ -77,10 +77,6 @@ pub struct Settings {
     pub telemetry: bool,
 }
 
-fn default_sink() -> String {
-    "stdout".into()
-}
-
 fn default_binance_options_poll_interval_secs() -> u64 {
     60
 }


### PR DESCRIPTION
## Summary
- remove unused `default_sink` helper
- keep other files formatted as before

## Testing
- `cargo test -p ingestor`

------
https://chatgpt.com/codex/tasks/task_e_68b4fe25dd5083238290f636eeb8b47e