### PR TITLE
Silence unused config warnings

### DIFF
--- a/crypto-ingestor/src/config.rs
+++ b/crypto-ingestor/src/config.rs
@@ -22,6 +22,7 @@ pub struct Cli {
 
 /// Application configuration loaded from file and environment
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
 pub struct Settings {
     pub binance_ws_url: String,
     pub binance_refresh_interval_mins: u64,
@@ -75,10 +76,6 @@ pub struct Settings {
     pub news_headlines: bool,
     #[serde(default)]
     pub telemetry: bool,
-}
-
-fn default_sink() -> String {
-    "stdout".into()
 }
 
 fn default_binance_options_poll_interval_secs() -> u64 {


### PR DESCRIPTION
## Summary
- silence dead code warnings for configuration fields
- remove unused `default_sink` helper

## Testing
- `cargo check -p ingestor`
- `cargo test -p ingestor`


------
https://chatgpt.com/codex/tasks/task_e_68b4fe4a6d9c8323b367e1c1f1ef5cd0