### PR TITLE
Add depth channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,25 @@ When either `binance:all` or `coinbase:all` agents are used, both exchanges
 subscribe only to USD-quoted pairs common to both platforms so their symbol
 sets align.
 
+## Order book formats
+
+When connected to order book depth streams, agents emit additional JSON lines:
+
+```json
+{"agent":"binance","type":"l2_diff","s":"BTC-USD","bids":[["30000.00","0.5"]],"asks":[["30010.00","1"]],"ts":1680000000000}
+```
+
+and periodic snapshots of the full book:
+
+```json
+{"agent":"coinbase","type":"snapshot","s":"BTC-USD","bids":[["30000.00","0.5"]],"asks":[["30010.00","1"]],"ts":1680000000000}
+```
+
+Fields:
+
+- `agent` – source exchange
+- `type` – either `l2_diff` or `snapshot`
+- `s` – canonical `BASE-QUOTE` symbol
+- `bids`/`asks` – arrays of `[price, quantity]` strings
+- `ts` – event timestamp in milliseconds since Unix epoch
+

--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -8,10 +8,10 @@ use crate::{
 };
 
 use super::{shared_symbols, AgentFactory};
-use canonicalizer::CanonicalService;
+use canonicalizer::{CanonicalService, L2Diff, Snapshot};
 
 const MAX_STREAMS_PER_CONN: usize = 1024; // per Binance docs
-const STREAMS_PER_SYMBOL: usize = 1; // trade only
+const STREAMS_PER_SYMBOL: usize = 2; // trade + depth
 
 /// Fetch all tradable symbols from Binance US REST API.
 pub async fn fetch_all_symbols() -> Result<Vec<String>, IngestorError> {
@@ -258,6 +258,9 @@ async fn connection_task(
                     tracing::error!(error=%e, "failed to send subscription");
                     continue;
                 }
+                if let Err(e) = send_snapshots(&current_symbols, &tx).await {
+                    tracing::error!(error=%e, "failed to fetch snapshots");
+                }
 
                 loop {
                     tokio::select! {
@@ -284,6 +287,9 @@ async fn connection_task(
                                         if let Err(e) = send_subscribe(&mut ws, &to_sub).await {
                                             tracing::error!(error=%e, "failed to update subscription");
                                             break;
+                                        }
+                                        if let Err(e) = send_snapshots(&to_sub, &tx).await {
+                                            tracing::error!(error=%e, "failed to fetch snapshots");
                                         }
                                     }
                                     current_symbols = new_syms;
@@ -348,6 +354,42 @@ async fn connection_task(
                                                     break;
                                                 }
                                             }
+                                            "depthUpdate" => {
+                                                let bids = v
+                                                    .get("b")
+                                                    .and_then(|b| b.as_array())
+                                                    .cloned()
+                                                    .unwrap_or_default()
+                                                    .into_iter()
+                                                    .filter_map(|lvl| {
+                                                        let p = lvl.get(0)?.as_str()?;
+                                                        let q = lvl.get(1)?.as_str()?;
+                                                        let p = parse_decimal_str(p)?;
+                                                        let q = parse_decimal_str(q)?;
+                                                        Some([p, q])
+                                                    })
+                                                    .collect::<Vec<[String; 2]>>();
+                                                let asks = v
+                                                    .get("a")
+                                                    .and_then(|a| a.as_array())
+                                                    .cloned()
+                                                    .unwrap_or_default()
+                                                    .into_iter()
+                                                    .filter_map(|lvl| {
+                                                        let p = lvl.get(0)?.as_str()?;
+                                                        let q = lvl.get(1)?.as_str()?;
+                                                        let p = parse_decimal_str(p)?;
+                                                        let q = parse_decimal_str(q)?;
+                                                        Some([p, q])
+                                                    })
+                                                    .collect::<Vec<[String; 2]>>();
+                                                let ts = v.get("E").and_then(|x| x.as_i64()).unwrap_or_default();
+                                                let evt = L2Diff::new("binance", raw, bids, asks, ts);
+                                                let line = evt.to_json_line();
+                                                if tx.send(line).await.is_err() {
+                                                    break;
+                                                }
+                                            }
                                             _ => {}
                                         }
                                     } else {
@@ -393,7 +435,7 @@ async fn send_subscribe(
 ) -> Result<(), tokio_tungstenite::tungstenite::Error> {
     let params = symbols
         .iter()
-        .map(|s| format!("{}@trade", s))
+        .flat_map(|s| vec![format!("{}@trade", s), format!("{}@depth@100ms", s)])
         .collect::<Vec<_>>();
     let sub_msg = serde_json::json!({
         "method": "SUBSCRIBE",
@@ -412,7 +454,7 @@ async fn send_unsubscribe(
     }
     let params = symbols
         .iter()
-        .map(|s| format!("{}@trade", s))
+        .flat_map(|s| vec![format!("{}@trade", s), format!("{}@depth@100ms", s)])
         .collect::<Vec<_>>();
     let msg = serde_json::json!({
         "method": "UNSUBSCRIBE",
@@ -420,4 +462,84 @@ async fn send_unsubscribe(
         "id": 1,
     });
     ws.send(Message::Text(msg.to_string())).await
+}
+
+async fn send_snapshots(
+    symbols: &[String],
+    tx: &mpsc::Sender<String>,
+) -> Result<(), IngestorError> {
+    for sym in symbols {
+        match fetch_snapshot(sym).await {
+            Ok(snap) => {
+                let line = snap.to_json_line();
+                if tx.send(line).await.is_err() {
+                    break;
+                }
+            }
+            Err(e) => {
+                tracing::error!(error=%e, symbol=%sym, "snapshot fetch failed");
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn fetch_snapshot(symbol: &str) -> Result<Snapshot, IngestorError> {
+    let client = http_client::builder()
+        .build()
+        .map_err(|e| IngestorError::Http {
+            source: e,
+            exchange: "binance",
+            symbol: Some(symbol.to_string()),
+        })?;
+    let url = format!(
+        "https://api.binance.us/api/v3/depth?symbol={}&limit=1000",
+        symbol.to_uppercase()
+    );
+    let resp: serde_json::Value = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| IngestorError::Http {
+            source: e,
+            exchange: "binance",
+            symbol: Some(symbol.to_string()),
+        })?
+        .json()
+        .await
+        .map_err(|e| IngestorError::Http {
+            source: e,
+            exchange: "binance",
+            symbol: Some(symbol.to_string()),
+        })?;
+    let bids = resp
+        .get("bids")
+        .and_then(|b| b.as_array())
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|lvl| {
+            let p = lvl.get(0)?.as_str()?;
+            let q = lvl.get(1)?.as_str()?;
+            let p = parse_decimal_str(p)?;
+            let q = parse_decimal_str(q)?;
+            Some([p, q])
+        })
+        .collect::<Vec<[String; 2]>>();
+    let asks = resp
+        .get("asks")
+        .and_then(|a| a.as_array())
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|lvl| {
+            let p = lvl.get(0)?.as_str()?;
+            let q = lvl.get(1)?.as_str()?;
+            let p = parse_decimal_str(p)?;
+            let q = parse_decimal_str(q)?;
+            Some([p, q])
+        })
+        .collect::<Vec<[String; 2]>>();
+    let ts = chrono::Utc::now().timestamp_millis();
+    Ok(Snapshot::new("binance", symbol, bids, asks, ts))
 }

--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -1,8 +1,8 @@
+use canonicalizer::{CanonicalService, L2Diff, Snapshot};
 use futures_util::{SinkExt, StreamExt};
 use std::collections::{HashMap, HashSet};
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
-use canonicalizer::CanonicalService;
 
 use crate::{
     agent::Agent, config::Settings, error::IngestorError, http_client, parse::parse_decimal_str,
@@ -318,7 +318,6 @@ async fn connection_task(
                                             },
                                             "l2update" => {
                                                 let raw = v.get("product_id").and_then(|s| s.as_str()).unwrap_or("?");
-                                                let sym = CanonicalService::canonical_pair("coinbase", raw).unwrap_or_else(|| raw.to_string());
                                                 let mut bids = Vec::new();
                                                 let mut asks = Vec::new();
                                                 if let Some(changes) = v.get("changes").and_then(|c| c.as_array()) {
@@ -346,20 +345,12 @@ async fn connection_task(
                                                     .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
                                                     .map(|dt| dt.timestamp_millis())
                                                     .unwrap_or_default();
-                                                let line = serde_json::json!({
-                                                    "agent": "coinbase",
-                                                    "type": "l2_diff",
-                                                    "s": sym,
-                                                    "bids": bids,
-                                                    "asks": asks,
-                                                    "ts": ts
-                                                }).to_string();
-                                                if tx.send(line).await.is_ok() {
-                                                } else { break; }
+                                                let evt = L2Diff::new("coinbase", raw, bids, asks, ts);
+                                                let line = evt.to_json_line();
+                                                if tx.send(line).await.is_err() { break; }
                                             }
                                             "snapshot" => {
                                                 let raw = v.get("product_id").and_then(|s| s.as_str()).unwrap_or("?");
-                                                let sym = CanonicalService::canonical_pair("coinbase", raw).unwrap_or_else(|| raw.to_string());
                                                 let bids = v
                                                     .get("bids")
                                                     .and_then(|b| b.as_array())
@@ -367,11 +358,13 @@ async fn connection_task(
                                                     .unwrap_or_default()
                                                     .into_iter()
                                                     .filter_map(|lvl| {
-                                                        let p = lvl.get(0)?.as_str()?.to_string();
-                                                        let q = lvl.get(1)?.as_str()?.to_string();
+                                                        let p = lvl.get(0)?.as_str()?;
+                                                        let q = lvl.get(1)?.as_str()?;
+                                                        let p = parse_decimal_str(p)?;
+                                                        let q = parse_decimal_str(q)?;
                                                         Some([p, q])
                                                     })
-                                                    .collect::<Vec<[String;2]>>();
+                                                    .collect::<Vec<[String; 2]>>();
                                                 let asks = v
                                                     .get("asks")
                                                     .and_then(|a| a.as_array())
@@ -379,22 +372,17 @@ async fn connection_task(
                                                     .unwrap_or_default()
                                                     .into_iter()
                                                     .filter_map(|lvl| {
-                                                        let p = lvl.get(0)?.as_str()?.to_string();
-                                                        let q = lvl.get(1)?.as_str()?.to_string();
+                                                        let p = lvl.get(0)?.as_str()?;
+                                                        let q = lvl.get(1)?.as_str()?;
+                                                        let p = parse_decimal_str(p)?;
+                                                        let q = parse_decimal_str(q)?;
                                                         Some([p, q])
                                                     })
-                                                    .collect::<Vec<[String;2]>>();
+                                                    .collect::<Vec<[String; 2]>>();
                                                 let ts = chrono::Utc::now().timestamp_millis();
-                                                let line = serde_json::json!({
-                                                    "agent": "coinbase",
-                                                    "type": "snapshot",
-                                                    "s": sym,
-                                                    "bids": bids,
-                                                    "asks": asks,
-                                                    "ts": ts
-                                                }).to_string();
-                                                if tx.send(line).await.is_ok() {
-                                                } else { break; }
+                                                let evt = Snapshot::new("coinbase", raw, bids, asks, ts);
+                                                let line = evt.to_json_line();
+                                                if tx.send(line).await.is_err() { break; }
                                             }
                                             _ => {}
                                         }
@@ -471,7 +459,7 @@ async fn send_subscribe(
     let msg = serde_json::json!({
         "type": "subscribe",
         "product_ids": symbols,
-        "channels": ["matches"],
+        "channels": ["level2", "matches"],
     });
     ws.send(Message::Text(msg.to_string())).await
 }
@@ -486,7 +474,7 @@ async fn send_unsubscribe(
     let msg = serde_json::json!({
         "type": "unsubscribe",
         "product_ids": symbols,
-        "channels": ["matches"],
+        "channels": ["level2", "matches"],
     });
     ws.send(Message::Text(msg.to_string())).await
 }


### PR DESCRIPTION
## Summary
- stream Binance depth@100ms and publish canonical l2_diff/snapshot events
- subscribe Coinbase to level2 and emit order book diffs and snapshots
- document l2 order book output formats

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b5025e65788323a11c92c7699b9030