### PR TITLE
Add trade bar aggregation with configurable output

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,13 @@ When either `binance:all` or `coinbase:all` agents are used, both exchanges
 subscribe only to USD-quoted pairs common to both platforms so their symbol
 sets align.
 
+
+## Bar aggregation
+
+Aggregate incoming trades into OHLCV bars by providing the `--bars` flag with an interval in seconds. Results are emitted as JSON `Bar` records. By default bars are written to `STDOUT`, but a file path may be supplied via `--output`.
+
+```bash
+cargo run --release -- --bars 60 binance:btcusdt
+cargo run --release -- --bars 300 --output bars.json binance:btcusdt coinbase:BTC-USD
+```
+

--- a/crypto-ingestor/src/bar.rs
+++ b/crypto-ingestor/src/bar.rs
@@ -1,0 +1,130 @@
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use canonicalizer::Bar;
+use rust_decimal::Decimal;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Trade {
+    agent: String,
+    #[serde(rename = "type")]
+    r#type: String,
+    #[serde(rename = "s")]
+    symbol: String,
+    #[serde(rename = "p")]
+    price: String,
+    #[serde(rename = "q")]
+    qty: String,
+    #[serde(rename = "ts")]
+    timestamp: i64,
+}
+
+struct RunningBar {
+    open: Decimal,
+    high: Decimal,
+    low: Decimal,
+    close: Decimal,
+    volume: Decimal,
+    start: i64,
+}
+
+pub struct BarAggregator {
+    interval: u64,
+    current: HashMap<(String, String), RunningBar>,
+}
+
+impl BarAggregator {
+    pub fn new(interval: u64) -> Self {
+        Self {
+            interval,
+            current: HashMap::new(),
+        }
+    }
+
+    /// Process a JSON line containing a trade event.
+    /// Returns a completed [`Bar`] if the previous interval closed.
+    pub fn process_line(&mut self, line: &str) -> Option<Bar> {
+        let trade: Trade = serde_json::from_str(line).ok()?;
+        if trade.r#type != "trade" {
+            return None;
+        }
+        let price = Decimal::from_str(&trade.price).ok()?;
+        let qty = Decimal::from_str(&trade.qty).ok()?;
+        let interval_ms = (self.interval * 1000) as i64;
+        let start = (trade.timestamp / interval_ms) * interval_ms;
+        let key = (trade.agent.clone(), trade.symbol.clone());
+        if let Some(rb) = self.current.get_mut(&key) {
+            if rb.start == start {
+                rb.close = price;
+                if price > rb.high {
+                    rb.high = price;
+                }
+                if price < rb.low {
+                    rb.low = price;
+                }
+                rb.volume += qty;
+                None
+            } else if start > rb.start {
+                let bar = Bar {
+                    agent: key.0.clone(),
+                    r#type: "ohlcv".into(),
+                    symbol: key.1.clone(),
+                    interval: self.interval,
+                    open: rb.open.to_string(),
+                    high: rb.high.to_string(),
+                    low: rb.low.to_string(),
+                    close: rb.close.to_string(),
+                    volume: rb.volume.to_string(),
+                    timestamp: rb.start,
+                };
+                *rb = RunningBar {
+                    open: price,
+                    high: price,
+                    low: price,
+                    close: price,
+                    volume: qty,
+                    start,
+                };
+                Some(bar)
+            } else {
+                // Ignore out-of-order trades
+                None
+            }
+        } else {
+            self.current.insert(
+                key,
+                RunningBar {
+                    open: price,
+                    high: price,
+                    low: price,
+                    close: price,
+                    volume: qty,
+                    start,
+                },
+            );
+            None
+        }
+    }
+
+    /// Drain and return all currently tracked bars.
+    pub fn drain(&mut self) -> Vec<Bar> {
+        let mut out = Vec::new();
+        for ((agent, symbol), rb) in self.current.drain() {
+            out.push(Bar {
+                agent,
+                r#type: "ohlcv".into(),
+                symbol,
+                interval: self.interval,
+                open: rb.open.to_string(),
+                high: rb.high.to_string(),
+                low: rb.low.to_string(),
+                close: rb.close.to_string(),
+                volume: rb.volume.to_string(),
+                timestamp: rb.start,
+            });
+        }
+        out
+    }
+}
+

--- a/crypto-ingestor/src/config.rs
+++ b/crypto-ingestor/src/config.rs
@@ -15,6 +15,14 @@ pub struct Cli {
     /// Enable trade feeds
     #[arg(long)]
     pub trades: bool,
+    /// Aggregate trades into bars of the given interval in seconds
+    #[arg(long, value_name = "SECS")]
+    pub bars: Option<u64>,
+
+    /// Output destination for bars; defaults to stdout
+    #[arg(long)]
+    pub output: Option<String>,
+
 
     /// Agent specifications (e.g. binance:btcusdt)
     pub specs: Vec<String>,

--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod error;
 mod http_client;
 mod parse;
+mod bar;
 mod sink;
 
 use agents::{available_agents, make_agent};
@@ -11,7 +12,8 @@ use canonicalizer::CanonicalService;
 use clap::Parser;
 use config::{Cli, Settings};
 use error::IngestorError;
-use sink::{DynSink, StdoutSink};
+use sink::{DynSink, FileSink, StdoutSink};
+use bar::BarAggregator;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::process::Command;
@@ -41,7 +43,11 @@ async fn main() -> Result<(), IngestorError> {
     let settings = Settings::load(&cli)?;
 
     // initialise output sink
-    let sink: DynSink = Arc::new(StdoutSink::new());
+    let sink: DynSink = if let Some(path) = &cli.output {
+        Arc::new(FileSink::new(path).await?)
+    } else {
+        Arc::new(StdoutSink::new())
+    };
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
@@ -69,10 +75,16 @@ async fn main() -> Result<(), IngestorError> {
     // spawn watchdog for canonicalizer process
     let canon_path_clone = canon_path.clone();
     let sink_clone = sink.clone();
+    let bar_interval = cli.bars;
     let canon_watchdog = tokio::spawn(async move {
         let mut rx = rx;
+        let mut bar_agg = bar_interval.map(BarAggregator::new);
         loop {
-            let mut canon_child = match Command::new(&canon_path_clone)
+            let mut cmd = Command::new(&canon_path_clone);
+            if bar_agg.is_some() {
+                cmd.arg("--json");
+            }
+            let mut canon_child = match cmd
                 .stdin(std::process::Stdio::piped())
                 .stdout(std::process::Stdio::piped())
                 .spawn()
@@ -94,12 +106,8 @@ async fn main() -> Result<(), IngestorError> {
                     line = rx.recv() => {
                         match line {
                             Some(line) => {
-                                if canon_stdin.write_all(line.as_bytes()).await.is_err() {
-                                    break;
-                                }
-                                if canon_stdin.write_all(b"\n").await.is_err() {
-                                    break;
-                                }
+                                if canon_stdin.write_all(line.as_bytes()).await.is_err() { break; }
+                                if canon_stdin.write_all(b"\n").await.is_err() { break; }
                             }
                             None => {
                                 let _ = canon_child.kill().await;
@@ -110,7 +118,14 @@ async fn main() -> Result<(), IngestorError> {
                     res = reader.next_line() => {
                         match res {
                             Ok(Some(line)) => {
-                                if let Err(e) = sink.send(&line).await {
+                                if let Some(agg) = bar_agg.as_mut() {
+                                    if let Some(bar) = agg.process_line(&line) {
+                                        let out = serde_json::to_string(&bar).unwrap_or_default();
+                                        if let Err(e) = sink.send(&out).await {
+                                            tracing::error!(error=%e, "sink error");
+                                        }
+                                    }
+                                } else if let Err(e) = sink.send(&line).await {
                                     tracing::error!(error=%e, "sink error");
                                 }
                             }
@@ -124,11 +139,19 @@ async fn main() -> Result<(), IngestorError> {
                 }
             }
 
+            if let Some(agg) = bar_agg.as_mut() {
+                for bar in agg.drain() {
+                    let out = serde_json::to_string(&bar).unwrap_or_default();
+                    if let Err(e) = sink.send(&out).await {
+                        tracing::error!(error=%e, "sink error");
+                    }
+                }
+            }
+
             let _ = canon_child.kill().await;
         }
     });
-
-    // Initialise the canonical service before any agents are created so that
+// Initialise the canonical service before any agents are created so that
     // the required quote asset list is available for symbol comparisons.
     CanonicalService::init().await;
 

--- a/crypto-ingestor/src/sink.rs
+++ b/crypto-ingestor/src/sink.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use std::sync::Arc;
+use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 
@@ -33,3 +34,31 @@ impl OutputSink for StdoutSink {
         Ok(())
     }
 }
+
+pub struct FileSink {
+    file: Mutex<tokio::fs::File>,
+}
+
+impl FileSink {
+    pub async fn new(path: &str) -> Result<Self, IngestorError> {
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .await?;
+        Ok(Self {
+            file: Mutex::new(file),
+        })
+    }
+}
+
+#[async_trait]
+impl OutputSink for FileSink {
+    async fn send(&self, line: &str) -> Result<(), IngestorError> {
+        let mut file = self.file.lock().await;
+        file.write_all(line.as_bytes()).await?;
+        file.write_all(b"\n").await?;
+        Ok(())
+    }
+}
+


### PR DESCRIPTION
## Summary
- support aggregating trades into OHLCV bars with new `BarAggregator`
- expose `--bars` and `--output` CLI flags to control bar interval and destination
- allow writing bar data to files via new `FileSink`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b50260e92c8323ad674bad8e8c4f02