### PR TITLE
feat: parallel canonicalizer pool

### DIFF
--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -1,20 +1,21 @@
 mod agent;
 mod agents;
+mod bar;
 mod config;
 mod error;
 mod http_client;
 mod parse;
-mod bar;
 mod sink;
 
 use agents::{available_agents, make_agent};
+use bar::BarAggregator;
 use canonicalizer::CanonicalService;
 use clap::Parser;
 use config::{Cli, Settings};
 use error::IngestorError;
 use sink::{DynSink, FileSink, StdoutSink};
-use bar::BarAggregator;
 use std::sync::Arc;
+use std::thread;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use tokio::sync::mpsc;
@@ -72,86 +73,110 @@ async fn main() -> Result<(), IngestorError> {
     }
     let (tx, rx) = mpsc::channel::<String>(100);
 
-    // spawn watchdog for canonicalizer process
-    let canon_path_clone = canon_path.clone();
-    let sink_clone = sink.clone();
-    let bar_interval = cli.bars;
-    let canon_watchdog = tokio::spawn(async move {
-        let mut rx = rx;
-        let mut bar_agg = bar_interval.map(BarAggregator::new);
-        loop {
-            let mut cmd = Command::new(&canon_path_clone);
-            if bar_agg.is_some() {
-                cmd.arg("--json");
-            }
-            let mut canon_child = match cmd
-                .stdin(std::process::Stdio::piped())
-                .stdout(std::process::Stdio::piped())
-                .spawn()
-            {
-                Ok(child) => child,
-                Err(e) => {
-                    tracing::error!(error=%e, "failed to spawn canonicalizer");
-                    return;
-                }
-            };
-
-            let mut canon_stdin = canon_child.stdin.take().expect("canonicalizer stdin");
-            let canon_stdout = canon_child.stdout.take().expect("canonicalizer stdout");
-            let mut reader = tokio::io::BufReader::new(canon_stdout).lines();
-            let sink = sink_clone.clone();
-
+    // spawn watchdog pool for canonicalizer processes
+    let worker_count = thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    let mut worker_senders = Vec::new();
+    let mut canon_handles = Vec::new();
+    for _ in 0..worker_count {
+        let (wtx, wrx) = mpsc::channel::<String>(100);
+        worker_senders.push(wtx);
+        let canon_path_clone = canon_path.clone();
+        let sink_clone = sink.clone();
+        let bar_interval = cli.bars;
+        canon_handles.push(tokio::spawn(async move {
+            let mut rx = wrx;
+            let mut bar_agg = bar_interval.map(BarAggregator::new);
             loop {
-                tokio::select! {
-                    line = rx.recv() => {
-                        match line {
-                            Some(line) => {
-                                if canon_stdin.write_all(line.as_bytes()).await.is_err() { break; }
-                                if canon_stdin.write_all(b"\n").await.is_err() { break; }
-                            }
-                            None => {
-                                let _ = canon_child.kill().await;
-                                return;
-                            }
-                        }
+                let mut cmd = Command::new(&canon_path_clone);
+                if bar_agg.is_some() {
+                    cmd.arg("--json");
+                }
+                let mut canon_child = match cmd
+                    .stdin(std::process::Stdio::piped())
+                    .stdout(std::process::Stdio::piped())
+                    .spawn()
+                {
+                    Ok(child) => child,
+                    Err(e) => {
+                        tracing::error!(error=%e, "failed to spawn canonicalizer");
+                        return;
                     }
-                    res = reader.next_line() => {
-                        match res {
-                            Ok(Some(line)) => {
-                                if let Some(agg) = bar_agg.as_mut() {
-                                    if let Some(bar) = agg.process_line(&line) {
-                                        let out = serde_json::to_string(&bar).unwrap_or_default();
-                                        if let Err(e) = sink.send(&out).await {
-                                            tracing::error!(error=%e, "sink error");
-                                        }
-                                    }
-                                } else if let Err(e) = sink.send(&line).await {
-                                    tracing::error!(error=%e, "sink error");
+                };
+
+                let mut canon_stdin = canon_child.stdin.take().expect("canonicalizer stdin");
+                let canon_stdout = canon_child.stdout.take().expect("canonicalizer stdout");
+                let mut reader = tokio::io::BufReader::new(canon_stdout).lines();
+                let sink = sink_clone.clone();
+
+                loop {
+                    tokio::select! {
+                        line = rx.recv() => {
+                            match line {
+                                Some(line) => {
+                                    if canon_stdin.write_all(line.as_bytes()).await.is_err() { break; }
+                                    if canon_stdin.write_all(b"\n").await.is_err() { break; }
+                                }
+                                None => {
+                                    let _ = canon_child.kill().await;
+                                    return;
                                 }
                             }
-                            _ => break,
+                        }
+                        res = reader.next_line() => {
+                            match res {
+                                Ok(Some(line)) => {
+                                    if let Some(agg) = bar_agg.as_mut() {
+                                        if let Some(bar) = agg.process_line(&line) {
+                                            let out = serde_json::to_string(&bar).unwrap_or_default();
+                                            if let Err(e) = sink.send(&out).await {
+                                                tracing::error!(error=%e, "sink error");
+                                            }
+                                        }
+                                    } else if let Err(e) = sink.send(&line).await {
+                                        tracing::error!(error=%e, "sink error");
+                                    }
+                                }
+                                _ => break,
+                            }
+                        }
+                        status = canon_child.wait() => {
+                            tracing::warn!(?status, "canonicalizer exited; restarting");
+                            break;
                         }
                     }
-                    status = canon_child.wait() => {
-                        tracing::warn!(?status, "canonicalizer exited; restarting");
-                        break;
+                }
+
+                if let Some(agg) = bar_agg.as_mut() {
+                    for bar in agg.drain() {
+                        let out = serde_json::to_string(&bar).unwrap_or_default();
+                        if let Err(e) = sink.send(&out).await {
+                            tracing::error!(error=%e, "sink error");
+                        }
                     }
                 }
-            }
 
-            if let Some(agg) = bar_agg.as_mut() {
-                for bar in agg.drain() {
-                    let out = serde_json::to_string(&bar).unwrap_or_default();
-                    if let Err(e) = sink.send(&out).await {
-                        tracing::error!(error=%e, "sink error");
-                    }
-                }
+                let _ = canon_child.kill().await;
             }
+        }));
+    }
 
-            let _ = canon_child.kill().await;
-        }
-    });
-// Initialise the canonical service before any agents are created so that
+    // dispatcher to partition input across workers (round-robin)
+    let dispatcher = {
+        let mut rx = rx;
+        let worker_senders = worker_senders.clone();
+        tokio::spawn(async move {
+            let mut idx = 0usize;
+            while let Some(line) = rx.recv().await {
+                let tx = &worker_senders[idx % worker_senders.len()];
+                let _ = tx.send(line).await;
+                idx += 1;
+            }
+            // dropping worker_senders closes worker channels
+        })
+    };
+    // Initialise the canonical service before any agents are created so that
     // the required quote asset list is available for symbol comparisons.
     CanonicalService::init().await;
 
@@ -194,7 +219,10 @@ async fn main() -> Result<(), IngestorError> {
     }
 
     drop(tx);
-    let _ = canon_watchdog.await;
+    let _ = dispatcher.await;
+    for h in canon_handles {
+        let _ = h.await;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- replace single canonicalizer watchdog with worker pool
- round-robin dispatcher partitions agent output across workers
- join dispatcher and workers on shutdown for graceful exit

## Testing
- `cargo test -p ingestor`

------
https://chatgpt.com/codex/tasks/task_e_68b507aeb1ec8323a321677c070d09ce