### PR TITLE
Refactor sink writers with async task

### DIFF
--- a/crypto-ingestor/src/sink.rs
+++ b/crypto-ingestor/src/sink.rs
@@ -1,8 +1,9 @@
 use async_trait::async_trait;
 use std::sync::Arc;
 use tokio::fs::OpenOptions;
-use tokio::io::AsyncWriteExt;
-use tokio::sync::Mutex;
+use tokio::io::{AsyncWrite, AsyncWriteExt, BufWriter};
+use tokio::sync::mpsc::{self, Sender};
+use tokio::time::{self, Duration};
 
 use crate::error::IngestorError;
 
@@ -13,30 +14,58 @@ pub trait OutputSink: Send + Sync {
 
 pub type DynSink = Arc<dyn OutputSink>;
 
+fn spawn_writer<W>(writer: W) -> Sender<String>
+where
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    let (tx, mut rx) = mpsc::channel::<String>(1024);
+    tokio::spawn(async move {
+        let mut writer = BufWriter::new(writer);
+        let mut interval = time::interval(Duration::from_secs(1));
+        loop {
+            tokio::select! {
+                line = rx.recv() => {
+                    match line {
+                        Some(line) => {
+                            if writer.write_all(line.as_bytes()).await.is_err() { break; }
+                            if writer.write_all(b"\n").await.is_err() { break; }
+                        }
+                        None => break,
+                    }
+                }
+                _ = interval.tick() => {
+                    if writer.flush().await.is_err() { break; }
+                }
+            }
+        }
+        let _ = writer.flush().await;
+    });
+    tx
+}
+
 pub struct StdoutSink {
-    stdout: Mutex<tokio::io::Stdout>,
+    tx: Sender<String>,
 }
 
 impl StdoutSink {
     pub fn new() -> Self {
-        Self {
-            stdout: Mutex::new(tokio::io::stdout()),
-        }
+        let tx = spawn_writer(tokio::io::stdout());
+        Self { tx }
     }
 }
 
 #[async_trait]
 impl OutputSink for StdoutSink {
     async fn send(&self, line: &str) -> Result<(), IngestorError> {
-        let mut stdout = self.stdout.lock().await;
-        stdout.write_all(line.as_bytes()).await?;
-        stdout.write_all(b"\n").await?;
-        Ok(())
+        self.tx
+            .send(line.to_string())
+            .await
+            .map_err(|e| IngestorError::Other(e.to_string()))
     }
 }
 
 pub struct FileSink {
-    file: Mutex<tokio::fs::File>,
+    tx: Sender<String>,
 }
 
 impl FileSink {
@@ -46,19 +75,17 @@ impl FileSink {
             .append(true)
             .open(path)
             .await?;
-        Ok(Self {
-            file: Mutex::new(file),
-        })
+        let tx = spawn_writer(file);
+        Ok(Self { tx })
     }
 }
 
 #[async_trait]
 impl OutputSink for FileSink {
     async fn send(&self, line: &str) -> Result<(), IngestorError> {
-        let mut file = self.file.lock().await;
-        file.write_all(line.as_bytes()).await?;
-        file.write_all(b"\n").await?;
-        Ok(())
+        self.tx
+            .send(line.to_string())
+            .await
+            .map_err(|e| IngestorError::Other(e.to_string()))
     }
 }
-


### PR DESCRIPTION
## Summary
- Replace sink mutexes with MPSC channels and dedicated writer tasks
- Use `BufWriter` for file and stdout sinks with periodic flushing

## Testing
- `cargo test -p crypto-ingestor` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*

------
https://chatgpt.com/codex/tasks/task_e_68b507c0fce88323b6eb9585c0322060