### PR TITLE
Add Binance quote refresh and optional refresher

### DIFF
--- a/canonicalizer/Cargo.toml
+++ b/canonicalizer/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "io-util"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "io-util", "time"] }
 reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }

--- a/canonicalizer/src/lib.rs
+++ b/canonicalizer/src/lib.rs
@@ -26,7 +26,7 @@ pub use events::{
 };
 
 use std::collections::HashSet;
-use std::sync::OnceLock;
+use std::sync::{OnceLock, RwLock};
 
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -34,12 +34,15 @@ use tracing::warn;
 pub struct CanonicalService;
 
 /// Cached list of Binance quote assets. Populated at startup via [`init`].
-static BINANCE_QUOTES: OnceLock<Vec<String>> = OnceLock::new();
+static BINANCE_QUOTES: OnceLock<RwLock<Vec<String>>> = OnceLock::new();
 
 impl CanonicalService {
     /// Initialise any resources required by the service. Currently this loads
     /// the list of Binance quote assets from the public `exchangeInfo` endpoint
     /// (unless provided via the `BINANCE_QUOTES` environment variable).
+    ///
+    /// If `BINANCE_QUOTES_REFRESH_INTERVAL_SECS` is set, a background task will
+    /// periodically refresh the cached quotes.
     ///
     /// Network errors are logged and fall back to a small built-in list.
     pub async fn init() {
@@ -47,22 +50,48 @@ impl CanonicalService {
             return;
         }
 
+        let quotes = Self::load_binance_quotes().await;
+        let _ = BINANCE_QUOTES.set(RwLock::new(quotes));
+
+        Self::maybe_spawn_binance_refresher();
+    }
+
+    async fn load_binance_quotes() -> Vec<String> {
         if let Ok(env) = std::env::var("BINANCE_QUOTES") {
-            let quotes = Self::parse_env_quotes(&env);
-            let _ = BINANCE_QUOTES.set(quotes);
-            return;
+            return Self::parse_env_quotes(&env);
         }
 
         match Self::fetch_binance_quotes().await {
-            Ok(quotes) if !quotes.is_empty() => {
-                let _ = BINANCE_QUOTES.set(quotes);
-            }
-            Ok(_) => {
-                let _ = BINANCE_QUOTES.set(Self::default_binance_quotes());
-            }
+            Ok(quotes) if !quotes.is_empty() => quotes,
+            Ok(_) => Self::default_binance_quotes(),
             Err(e) => {
                 warn!("failed to fetch Binance quotes: {}", e);
-                let _ = BINANCE_QUOTES.set(Self::default_binance_quotes());
+                Self::default_binance_quotes()
+            }
+        }
+    }
+
+    /// Re-fetch the Binance quote assets and replace the cached set.
+    pub async fn refresh_binance_quotes() {
+        let quotes = Self::load_binance_quotes().await;
+        let lock = Self::binance_quotes();
+        if let Ok(mut guard) = lock.write() {
+            *guard = quotes;
+        }
+    }
+
+    /// Spawn a background task to refresh Binance quotes if configured via
+    /// the `BINANCE_QUOTES_REFRESH_INTERVAL_SECS` environment variable.
+    pub fn maybe_spawn_binance_refresher() {
+        if let Ok(val) = std::env::var("BINANCE_QUOTES_REFRESH_INTERVAL_SECS") {
+            if let Ok(secs) = val.parse::<u64>() {
+                tokio::spawn(async move {
+                    let mut int = tokio::time::interval(std::time::Duration::from_secs(secs));
+                    loop {
+                        int.tick().await;
+                        CanonicalService::refresh_binance_quotes().await;
+                    }
+                });
             }
         }
     }
@@ -78,8 +107,8 @@ impl CanonicalService {
         }
     }
 
-    fn binance_quotes() -> &'static Vec<String> {
-        BINANCE_QUOTES.get_or_init(Self::default_binance_quotes)
+    fn binance_quotes() -> &'static RwLock<Vec<String>> {
+        BINANCE_QUOTES.get_or_init(|| RwLock::new(Self::default_binance_quotes()))
     }
 
     async fn fetch_binance_quotes() -> Result<Vec<String>, reqwest::Error> {
@@ -122,7 +151,8 @@ impl CanonicalService {
 
     fn canonicalize_binance(symbol: &str) -> Option<String> {
         let lower = symbol.to_lowercase();
-        for q in Self::binance_quotes() {
+        let quotes = Self::binance_quotes().read().ok()?;
+        for q in quotes.iter() {
             if lower.ends_with(q) {
                 let base = &lower[..lower.len() - q.len()];
                 if base.is_empty() {
@@ -159,7 +189,10 @@ impl CanonicalService {
     pub fn set_binance_quotes(quotes: Vec<&str>) {
         let mut qs: Vec<String> = quotes.into_iter().map(|s| s.to_lowercase()).collect();
         qs.sort_by(|a, b| b.len().cmp(&a.len()));
-        let _ = BINANCE_QUOTES.set(qs);
+        let lock = BINANCE_QUOTES.get_or_init(|| RwLock::new(Vec::new()));
+        if let Ok(mut guard) = lock.write() {
+            *guard = qs;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add `refresh_binance_quotes` to re-fetch Binance quote assets
- optional background refresher controlled by `BINANCE_QUOTES_REFRESH_INTERVAL_SECS`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b507d3c748832391d39e5fd563bd7d