### PR TITLE
Handle serialization errors in to_json_line methods

### DIFF
--- a/canonicalizer/src/lib.rs
+++ b/canonicalizer/src/lib.rs
@@ -197,8 +197,8 @@ impl L2Diff {
         }
     }
 
-    pub fn to_json_line(&self) -> String {
-        serde_json::to_string(self).unwrap_or_default()
+    pub fn to_json_line(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
     }
 }
 
@@ -236,8 +236,8 @@ impl Snapshot {
         }
     }
 
-    pub fn to_json_line(&self) -> String {
-        serde_json::to_string(self).unwrap_or_default()
+    pub fn to_json_line(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
     }
 }
 

--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -385,9 +385,15 @@ async fn connection_task(
                                                     .collect::<Vec<[String; 2]>>();
                                                 let ts = v.get("E").and_then(|x| x.as_i64()).unwrap_or_default();
                                                 let evt = L2Diff::new("binance", raw, bids, asks, ts);
-                                                let line = evt.to_json_line();
-                                                if tx.send(line).await.is_err() {
-                                                    break;
+                                                match evt.to_json_line() {
+                                                    Ok(line) => {
+                                                        if tx.send(line).await.is_err() {
+                                                            break;
+                                                        }
+                                                    }
+                                                    Err(e) => {
+                                                        tracing::error!(error=%e, "failed to serialize l2 diff");
+                                                    }
                                                 }
                                             }
                                             _ => {}
@@ -471,7 +477,9 @@ async fn send_snapshots(
     for sym in symbols {
         match fetch_snapshot(sym).await {
             Ok(snap) => {
-                let line = snap.to_json_line();
+                let line = snap
+                    .to_json_line()
+                    .map_err(|e| IngestorError::Other(format!("failed to serialize snapshot: {e}")))?;
                 if tx.send(line).await.is_err() {
                     break;
                 }

--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -346,8 +346,14 @@ async fn connection_task(
                                                     .map(|dt| dt.timestamp_millis())
                                                     .unwrap_or_default();
                                                 let evt = L2Diff::new("coinbase", raw, bids, asks, ts);
-                                                let line = evt.to_json_line();
-                                                if tx.send(line).await.is_err() { break; }
+                                                match evt.to_json_line() {
+                                                    Ok(line) => {
+                                                        if tx.send(line).await.is_err() { break; }
+                                                    }
+                                                    Err(e) => {
+                                                        tracing::error!(error=%e, "failed to serialize l2 diff");
+                                                    }
+                                                }
                                             }
                                             "snapshot" => {
                                                 let raw = v.get("product_id").and_then(|s| s.as_str()).unwrap_or("?");
@@ -381,8 +387,14 @@ async fn connection_task(
                                                     .collect::<Vec<[String; 2]>>();
                                                 let ts = chrono::Utc::now().timestamp_millis();
                                                 let evt = Snapshot::new("coinbase", raw, bids, asks, ts);
-                                                let line = evt.to_json_line();
-                                                if tx.send(line).await.is_err() { break; }
+                                                match evt.to_json_line() {
+                                                    Ok(line) => {
+                                                        if tx.send(line).await.is_err() { break; }
+                                                    }
+                                                    Err(e) => {
+                                                        tracing::error!(error=%e, "failed to serialize snapshot");
+                                                    }
+                                                }
                                             }
                                             _ => {}
                                         }


### PR DESCRIPTION
## Summary
- Have `L2Diff::to_json_line` and `Snapshot::to_json_line` return `Result<String, serde_json::Error>`
- Log serialization failures in Binance and Coinbase websocket handlers
- Propagate snapshot serialization errors in Binance snapshot sender

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b507d224cc8323a15286a8382a194f