### PR TITLE
test: add edge case coverage

### DIFF
--- a/canonicalizer/src/lib.rs
+++ b/canonicalizer/src/lib.rs
@@ -294,4 +294,45 @@ mod tests {
     fn unknown_exchange_returns_none() {
         assert_eq!(CanonicalService::canonical_pair("kraken", "btcusd"), None);
     }
+
+    #[test]
+    fn parse_env_quotes_handles_empty_and_malformed_input() {
+        // Empty string yields no quotes
+        let quotes = CanonicalService::parse_env_quotes("");
+        assert!(quotes.is_empty());
+
+        // Strings with only commas or whitespace also yield no quotes
+        let quotes = CanonicalService::parse_env_quotes(" , , ");
+        assert!(quotes.is_empty());
+
+        // Malformed entries are filtered out and the remaining quotes are sorted
+        let quotes = CanonicalService::parse_env_quotes("USDT,,USD,");
+        assert_eq!(quotes, vec!["usdt".to_string(), "usd".to_string()]);
+    }
+
+    #[test]
+    fn binance_canonicalize_unknown_or_malformed_symbols() {
+        setup();
+
+        // Unknown quote asset results in None
+        assert_eq!(CanonicalService::canonicalize_binance("BTCFOO"), None);
+
+        // Missing base symbol also results in None
+        assert_eq!(CanonicalService::canonicalize_binance("USDT"), None);
+    }
+
+    #[test]
+    fn coinbase_canonicalize_unknown_or_malformed_symbols() {
+        // Unknown quote with separator remains uppercased
+        assert_eq!(
+            CanonicalService::canonicalize_coinbase("foo-bar"),
+            "FOO-BAR".to_string()
+        );
+
+        // Without a separator and an unknown quote the string is simply uppercased
+        assert_eq!(
+            CanonicalService::canonicalize_coinbase("foobarbaz"),
+            "FOOBARBAZ".to_string()
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- verify `parse_env_quotes` cleans empty and malformed lists
- test `canonicalize_binance` and `canonicalize_coinbase` with invalid symbols

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b507d4de248323bef0a60ab0c12827