### PR TITLE
Add logging for canonicalization failures

### DIFF
--- a/canonicalizer/src/lib.rs
+++ b/canonicalizer/src/lib.rs
@@ -126,11 +126,13 @@ impl CanonicalService {
             if lower.ends_with(q) {
                 let base = &lower[..lower.len() - q.len()];
                 if base.is_empty() {
+                    warn!("binance: failed to parse base asset for '{symbol}'");
                     return None;
                 }
                 return Some(format!("{}-{}", base.to_uppercase(), q.to_uppercase()));
             }
         }
+        warn!("binance: failed to detect quote asset for '{symbol}'");
         None
     }
 
@@ -151,7 +153,7 @@ impl CanonicalService {
                 }
             }
         }
-
+        warn!("coinbase: failed to canonicalize '{symbol}'");
         lower.to_uppercase()
     }
 


### PR DESCRIPTION
## Summary
- log failed parsing of Binance symbols before returning `None`
- warn when Coinbase symbol canonicalization falls back to original

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b507d2d15083239aeef7e59bc73204