### PR TITLE
Add shared spec option for exchange symbol selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,10 @@ Fields:
 - `q` – quantity as a string
 - `ts` – trade timestamp in milliseconds since Unix epoch
 
-When either `binance:all` or `coinbase:all` agents are used, both exchanges
-subscribe only to USD-quoted pairs common to both platforms so their symbol
-sets align.
+When either `binance:shared` or `coinbase:shared` agents are used, both
+exchanges subscribe only to USD-quoted pairs common to both platforms so their
+symbol sets align. Use `binance:all` or `coinbase:all` to stream every tradable
+symbol on the respective exchange.
 
 
 ## Bar aggregation

--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -206,6 +206,14 @@ pub struct BinanceFactory;
 impl AgentFactory for BinanceFactory {
     async fn create(&self, spec: &str, cfg: &Settings) -> Option<Box<dyn Agent>> {
         let symbols = if spec.is_empty() || spec.eq_ignore_ascii_case("all") {
+            match fetch_all_symbols().await {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    tracing::error!(error=%e, "failed to fetch binance symbols");
+                    return None;
+                }
+            }
+        } else if spec.eq_ignore_ascii_case("shared") {
             match shared_symbols().await {
                 Ok((b, _)) => Some(b),
                 Err(e) => {

--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -435,6 +435,14 @@ impl AgentFactory for CoinbaseFactory {
         let symbols = if spec.is_empty() {
             vec!["BTC-USD".to_string()]
         } else if spec.eq_ignore_ascii_case("all") {
+            match fetch_all_symbols().await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::error!(error=%e, "failed to fetch coinbase symbols");
+                    return None;
+                }
+            }
+        } else if spec.eq_ignore_ascii_case("shared") {
             match shared_symbols().await {
                 Ok((_, c)) => c,
                 Err(e) => {

--- a/crypto-ingestor/src/agents/mod.rs
+++ b/crypto-ingestor/src/agents/mod.rs
@@ -55,7 +55,7 @@ async fn shared_symbols() -> Result<(Vec<String>, Vec<String>), IngestorError> {
 }
 
 /// Factory: "<agent>:<comma-separated-args>"
-/// e.g., "binance:btcusdt,ethusdt" or "binance:all"
+/// e.g., "binance:btcusdt,ethusdt", "binance:all", or "binance:shared"
 pub async fn make_agent(spec: &str, cfg: &Settings) -> Option<Box<dyn Agent>> {
     let (name, args) = match spec.split_once(':') {
         Some((n, a)) => (n.trim().to_lowercase(), a.trim().to_string()),


### PR DESCRIPTION
## Summary
- Stream every Binance or Coinbase symbol when using `:all`
- Add `:shared` spec to fetch only symbols common to both exchanges
- Document new symbol-selection behavior

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b50800174483239ab0488e8e9e11e2