### PR TITLE
Remove quote currency filters for full market list

### DIFF
--- a/crypto-ingestor/src/agents/binance/mod.rs
+++ b/crypto-ingestor/src/agents/binance/mod.rs
@@ -46,12 +46,6 @@ pub async fn fetch_all_symbols() -> Result<Vec<String>, IngestorError> {
         .unwrap_or_default()
         .into_iter()
         .filter(|s| s.get("status").and_then(|st| st.as_str()) == Some("TRADING"))
-        .filter(|s| {
-            s.get("quoteAsset")
-                .and_then(|q| q.as_str())
-                .map(|q| q.eq_ignore_ascii_case("USD") || q.eq_ignore_ascii_case("USDT"))
-                .unwrap_or(false)
-        })
         .filter_map(|s| {
             s.get("symbol")
                 .and_then(|sym| sym.as_str())

--- a/crypto-ingestor/src/agents/coinbase/mod.rs
+++ b/crypto-ingestor/src/agents/coinbase/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use super::{shared_symbols, AgentFactory};
 
-/// Fetch all tradable USD product IDs from Coinbase.
+/// Fetch all tradable product IDs from Coinbase.
 pub async fn fetch_all_symbols() -> Result<Vec<String>, IngestorError> {
     let client = http_client::builder()
         .build()
@@ -41,7 +41,12 @@ pub async fn fetch_all_symbols() -> Result<Vec<String>, IngestorError> {
         .ok_or_else(|| IngestorError::Other("coinbase unexpected response".into()))?;
     let mut symbols = Vec::new();
     for prod in arr {
-        if prod.get("quote_currency").and_then(|q| q.as_str()) == Some("USD") {
+        let status_ok = prod
+            .get("status")
+            .and_then(|s| s.as_str())
+            .map(|s| s.eq_ignore_ascii_case("online"))
+            .unwrap_or(false);
+        if status_ok {
             if let Some(id) = prod.get("id").and_then(|i| i.as_str()) {
                 symbols.push(id.to_string());
             }


### PR DESCRIPTION
## Summary
- Drop Binance quote asset filter to return all trading pairs in lowercase
- Fetch all active Coinbase markets regardless of quote currency, ensuring IDs remain uppercase

## Testing
- `cargo test` *(fails: command hung during ingestor compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68b50801b79c8323a4fe8e7da6b7d01f