### PR TITLE
Fix broken Cargo.lock dependencies array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,9 @@ dependencies = [
  "once_cell",
  "version_check",
  "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
## Summary
- close the `ahash` dependency list in Cargo.lock

## Testing
- `cargo check` *(fails: unclosed delimiter in canonicalizer/src/lib.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68b50d88e738832390d0fd0222b362f3