### PR TITLE
Remove unused bar module from binary

### DIFF
--- a/crypto-ingestor/src/lib.rs
+++ b/crypto-ingestor/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod agents;
+pub mod bar;
 pub mod config;
 pub mod error;
 pub mod http_client;

--- a/crypto-ingestor/src/main.rs
+++ b/crypto-ingestor/src/main.rs
@@ -1,6 +1,5 @@
 mod agent;
 mod agents;
-mod bar;
 mod config;
 mod error;
 mod http_client;


### PR DESCRIPTION
## Summary
- Expose `bar` module through the library
- Drop unused `bar` module from the binary to avoid dead code warnings

## Testing
- `cargo test -p ingestor -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6452819b48323be66af1f6632ac96